### PR TITLE
Add Development team member Kiryl Oblikau

### DIFF
--- a/docs/contributions/how-to-contribute.md
+++ b/docs/contributions/how-to-contribute.md
@@ -34,6 +34,7 @@ Our open-source projects are maintained by a dedicated team of developers. Feel 
 | Jordan Cooper           | [JCoops1](https://github.com/JCoops1)                         |
 | Jose Bondi              | [joseUltra](https://github.com/joseUltra)                     |
 | Kirill Viarbitski       | [Kverbitski](https://github.com/Kverbitski)                   |
+| Kiryl Oblikau           | [muknex](https://github.com/munknex)                          |
 | Lakshantha Dissanayake  | [lakshanthad](https://github.com/lakshanthad)                 |
 | Marius Keiser           | [Skillnoob](https://github.com/Skillnoob)                     |
 | Mohammed Yasin          | [Y-T-G](https://github.com/Y-T-G)                             |


### PR DESCRIPTION
Add myself (Kiryl Oblikau @munknex) as Development team member.

I have read the CLA Document and I sign the CLA.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added a new contributor to the Ultralytics open-source team documentation. 🎉  

### 📊 Key Changes  
- Included **Kiryl Oblikau** ([muknex](https://github.com/munknex)) in the contributor list of the "How to Contribute" guide.  

### 🎯 Purpose & Impact  
- 🏆 Recognizes and highlights the contributions of a new team member.  
- 🤝 Encourages collaboration by showcasing the growing team behind Ultralytics projects.  
- 🌟 Enhances transparency and inclusivity within the open-source community.