### PR TITLE
 Fix Rippling MDM enrollment link in hardware policy

### DIFF
--- a/docs/tools/hardware.md
+++ b/docs/tools/hardware.md
@@ -92,7 +92,7 @@ This process applies when replacing an existing device with a new one.
 **All devices used for work, whether company-provided or personally owned (under BYOD), must have Rippling Mobile Device Management (MDM) installed.**
 
 - **Applies To:** MacBook Air/Pro, iPads, iPhones, and Android devices.
-- **Installation:** Employees are responsible for installing Rippling MDM from **[rippling.com/device-management](https://www.rippling.com/device-management)**.
+- **Installation:** Employees are responsible for installing Rippling MDM from **[app.rippling.com/enroll-device](https://app.rippling.com/enroll-device)**.
 - **Timing:** MDM must be installed **before** the device is used to access any company data or systems.
 
 ### Security & Compliance Policies


### PR DESCRIPTION
 Updates the Rippling MDM installation link in the Hardware Policy documentation to point to the correct enrollment URL instead of the marketing page.

  ## Changes
  - Changed MDM installation link from `https://www.rippling.com/device-management` (marketing page) to
  `https://app.rippling.com/enroll-device` (actual enrollment page)

  ## Why
  The previous link directed employees to Rippling's marketing page with "Start your trial" instead of the actual MDM profile installation steps, causing confusion during device setup.
