### PR TITLE
Remove `click==8.2.1` from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs>=1.6.0
 mkdocs-material>=9.6.15
 mkdocs-ultralytics-plugin>=0.1.26
-click==8.2.1 # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568


### PR DESCRIPTION
@onuralpszr this one too

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Unpins the Click dependency for the docs build, removing a temporary workaround and allowing the latest compatible version to be installed. ✅

### 📊 Key Changes
- Removed `click==8.2.1` pin from `requirements.txt` (was pinned due to a past MkDocs bug).
- Retains existing docs dependencies:
  - `mkdocs>=1.6.0`
  - `mkdocs-material>=9.6.15`
  - `mkdocs-ultralytics-plugin>=0.1.26`

### 🎯 Purpose & Impact
- Enables the latest Click releases, improving compatibility, security, and bug fixes for contributors building the handbook. 🚀
- Simplifies dependency management and reduces the risk of version conflicts in local and CI environments. 🧩
- Removes a now-unnecessary workaround; if any upstream issue resurfaces, builds should be monitored, but stability is expected to improve. 🔍

See the Ultralytics Docs for details: https://docs.ultralytics.com