### PR TITLE
Fix code-of-business-conduct-and-ethics.md emoji in link

### DIFF
--- a/docs/legal/code-of-business-conduct-and-ethics.md
+++ b/docs/legal/code-of-business-conduct-and-ethics.md
@@ -19,7 +19,7 @@ This Code establishes essential guidelines for ethical behavior and legal compli
 
 Violations of applicable laws, company policies, or this Code can result in serious individual consequences, including disciplinary actions and dismissal. These violations also create significant risks for Ultralytics as a whole, potentially exposing the company to legal liability, reputational damage, and threats to our operational continuity.
 
-We trust you to exercise sound judgment and maintain the highest ethical standards in all business decisions. When facing uncertainty or ethical dilemmas, we encourage you to seek guidance and raise concerns promptly. For assistance or to report concerns, contact legal@ultralytics.com. Additional information on how to report concerns can be found in the final section, [Raising Concerns and Getting Help](#raising-concerns-and-getting-help-).
+We trust you to exercise sound judgment and maintain the highest ethical standards in all business decisions. When facing uncertainty or ethical dilemmas, we encourage you to seek guidance and raise concerns promptly. For assistance or to report concerns, contact legal@ultralytics.com. Additional information on how to report concerns can be found in the final section, [Raising Concerns and Getting Help](#raising-concerns-and-getting-help).
 
 ## Creating an Inclusive and Safe Workplace 🏡
 
@@ -213,7 +213,7 @@ To keep our systems secure, ensure productivity, and protect sensitive informati
 
 Monitoring is done only when needed for legitimate business reasons such as security checks, compliance reviews, or to investigate potential misuse. We don’t monitor without cause, and we aim to be transparent about how we handle digital tools and data. To support these monitoring objectives, we deploy a mobile device management (MDM) solution to all devices that access company systems and data. For more details, refer to our approved [Hardware Policy](https://handbook.ultralytics.com/tools/hardware/).
 
-## Raising Concerns and Getting Help ☎️
+## Raising Concerns and Getting Help
 
 Living up to our Code of Conduct is something we all share. If something doesn’t seem right, you’re encouraged and expected to speak up. Whether it’s a potential breach of our values, a legal concern, or just something that feels ethically questionable, raising it early helps prevent bigger issues and shows our commitment to integrity and trust.
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes an internal anchor link and streamlines a section heading to ensure reliable navigation and a more professional presentation. ✅

### 📊 Key Changes
- Corrected an internal link target from `#raising-concerns-and-getting-help-` to `#raising-concerns-and-getting-help`.
- Removed the phone emoji from the section heading, changing “Raising Concerns and Getting Help ☎️” to “Raising Concerns and Getting Help”.

### 🎯 Purpose & Impact
- Improves navigation by preventing a broken/incorrect anchor link 🔗.
- Ensures consistent, clean headings for better readability and a more professional tone ✨.
- No policy content changes—this is purely a documentation/UX polish.
- Minimal user impact; however, any external bookmarks pointing to the old anchor may need updating.