### PR TITLE
Update development team profiles

### DIFF
--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -48,7 +48,6 @@ Our open-source projects are maintained by a dedicated team of developers. Feel 
 | Yogendra Singh          | [yogendrasinghx](https://github.com/yogendrasinghx)           |
 | Tigran Hakobyan         | [tthakz](https://github.com/tthakz)                           |
 | Zinnia Pourdad          | [zinnialp](https://github.com/zinnialp)                       |
-| Lynne Swan              | [DubLynne](https://github.com/DubLynne)                       |
 | Shuai (Louis) LYU       | [ShuaiLYU](https://github.com/ShuaiLYU)                       |
 | Abi Anderson            | [UltralyticsAbi](https://github.com/UltralyticsAbi)           |
 | Jin Xu                  | [laodouya](https://github.com/laodouya)                       |


### PR DESCRIPTION
@glenn-jocher FYI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removes an inactive contributor from the Handbook’s “How to Contribute” contributors list to keep documentation current. ✅

### 📊 Key Changes
- Removed contributor entry: Lynne Swan (GitHub: @DubLynne) from `docs/en/contributions/how-to-contribute.md` 👤🗑️

### 🎯 Purpose & Impact
- Ensures the contributors list reflects active maintainers and current project status 📌
- Reduces potential confusion for new contributors looking for points of contact 🧭
- Pure documentation cleanup—no changes to features, APIs, or user workflows 🧹