### PR TITLE
Update Banner Text

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
   target="_blank"
 >
   <div class="banner-content-wrapper">
-    <p>Register now for</p>
+    <p>Join now</p>
     <img
       src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/6895ca9b3ece7244d9981ab9_yv25-logo.avif"
       loading="lazy"


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the docs banner CTA text from “Register now for” to a shorter “Join now” to improve clarity and engagement. ✨

### 📊 Key Changes
- 📝 Replaces banner copy in `docs/overrides/main.html`: “Register now for” → “Join now”
- 🎯 No structural, style, or functional changes—copy-only update

### 🎯 Purpose & Impact
- 🚀 Clearer, more concise call-to-action likely improves click-through and user engagement
- 📱 Shorter text can display better on smaller screens
- 🧩 Zero risk to functionality; purely user-facing wording change