### PR TITLE
Fix GitHub link replacements

### DIFF
--- a/docs/postprocess.py
+++ b/docs/postprocess.py
@@ -12,12 +12,12 @@ def fix_md(site_dir: Path = Path("site")) -> None:
     for html_file in site_dir.rglob("*.html"):
         content = html_file.read_text(encoding="utf-8")
         lines = []
-        for line in content.split('\n'):
-            if 'github.com' not in line:
+        for line in content.split("\n"):
+            if "github.com" not in line:
                 line = line.replace("index.md", "")
                 line = re.sub(r'(["\']?)([^"\'>\s]+?)\.md(["\']?)', r"\1\2/\3", line)
             lines.append(line)
-        html_file.write_text('\n'.join(lines), encoding="utf-8")
+        html_file.write_text("\n".join(lines), encoding="utf-8")
     print(f"Post-processed {sum(1 for _ in site_dir.rglob('*.html'))} HTML files")
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improve docs post-processing by avoiding rewriting GitHub links while still converting internal `.md` links to clean trailing-slash URLs. ✅

### 📊 Key Changes
- Update `fix_md` to skip lines containing `github.com` when replacing `.md` with trailing slashes.
- Preserve GitHub URLs by processing content line-by-line and applying replacements only to non-GitHub lines.
- Adjust docstring to reflect the new behavior.

### 🎯 Purpose & Impact
- Prevents broken external GitHub links in generated HTML pages. 🔗
- Keeps internal links clean and consistent (e.g., `page.md` → `page/`). 🧭
- Improves reliability of the docs site with minimal performance overhead. ⚙️