### PR TITLE
Add PTO negative balance limit

### DIFF
--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -67,15 +67,15 @@ graph LR
     style E fill:#fff3cd
 ```
 
-| Limit Type                  | Amount                                  |
-| --------------------------- | --------------------------------------- |
-| **Maximum balance**         | 35 days total                           |
-| **Annual carryover**        | Up to 10 days                           |
-| **Rollover usage window**   | 12 months (no mid-year expiry)          |
-| **Longest single vacation** | 35 days (subject to balance/approval)   |
-| **Negative balance**        | Up to 5 days (manager approval)         |
-| **Vacation waiting period** | 30 days after start date                |
-| **Excess days**             | Forfeited (use it or lose it)           |
+| Limit Type                  | Amount                                |
+| --------------------------- | ------------------------------------- |
+| **Maximum balance**         | 35 days total                         |
+| **Annual carryover**        | Up to 10 days                         |
+| **Rollover usage window**   | 12 months (no mid-year expiry)        |
+| **Longest single vacation** | 35 days (subject to balance/approval) |
+| **Negative balance**        | Up to 5 days (manager approval)       |
+| **Vacation waiting period** | 30 days after start date              |
+| **Excess days**             | Forfeited (use it or lose it)         |
 
 **Rollover usage:** Carried-over days can be used at any time during the following calendar year (12 months).
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Ultralytics PTO policy docs to clarify when vacation can be taken, how rollover works, and new limits on balances and long trips 🏖️

---

### 📊 Key Changes
- Clarifies that the **full PTO allocation is granted on day one**, but **vacation days can only be taken after 30 days of employment**.
- Expands the **Balance Limits** table with:
  - Maximum PTO balance: **35 days**
  - Annual carryover: **up to 10 days**
  - **Rollover usage window:** 12 months with **no mid-year expiry**
  - **Longest single vacation:** up to **35 days** (depending on balance and approval)
  - **Negative balance:** up to **5 days** allowed with manager approval
  - **Vacation waiting period:** 30 days after start date
  - **Excess days:** still forfeited (“use it or lose it”)
- Adds a **“Rollover usage”** note explaining that carried‑over days can be used at any time in the following calendar year.
- Updates the **PTO checklist** with reminders about:
  - 30‑day waiting period before using vacation
  - 35‑day maximum for a single vacation
  - Possibility of going up to 5 days negative with manager approval ✈️

---

### 🎯 Purpose & Impact
- 🧭 **Improved clarity:** Makes PTO rules easier to understand for new and existing employees, especially around when vacation can start and how long trips can be.
- 🕒 **Better planning:** The 12‑month rollover window and explicit 35‑day max trip help employees and managers plan longer vacations without confusion.
- 🤝 **Flexibility with safeguards:** Allowing a small negative PTO balance (with approval) gives employees flexibility for important events while maintaining oversight.
- 📚 **More accurate documentation:** Aligns written policy with actual practices, reducing misinterpretations and HR overhead from repeated questions.