### PR TITLE
Update style.css to hide language switcher

### DIFF
--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -222,7 +222,8 @@ table td:nth-child(2):last-child {
 }
 
 /* Global kill-switch for Weglot UI */
-.weglot-container .country-selector .weglot-container,
+.weglot-container,
+.weglot_switcher,
 [id^="weglot-switcher"],
 .weglot-container[id^="weglot-switcher"] {
   display: none !important;


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR globally hides the Weglot translation UI across the handbook site and removes unused custom search bar styling. ✨

### 📊 Key Changes
- 🧹 Adds a **global CSS "kill switch"** that hides all Weglot UI elements (`.weglot-container`, `.weglot_switcher`, and related IDs).
- 🗑️ Removes legacy CSS styles related to the custom Ultralytics search bar (button layout, hover effects, and scaling).

### 🎯 Purpose & Impact
- 🚫 **Disables Weglot UI site-wide**, preventing translation widgets from appearing where they are not desired or not yet supported.
- 🧼 **Cleans up unused styles**, simplifying the stylesheet and reducing potential CSS conflicts.
- ⚙️ **Improves maintainability**, making it easier to manage future UI changes without unexpected interactions from leftover styles.