### PR TITLE
Revert "Custom language switcher"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,16 @@ extra: # version:
       link: https://reddit.com/r/ultralytics
     - icon: fontawesome/brands/weixin
       link: https://weixin.qq.com/r/mp/LxckPDfEgWr_rXNf90I9
+  alternate:
+    - name: 🇬🇧 English
+      link: /
+      lang: en
+    - name: 🇨🇳 简体中文
+      link: /zh/
+      lang: zh
+    - name: 🇪🇸 Español
+      link: /es/
+      lang: es
 
 extra_css:
   - stylesheets/style.css


### PR DESCRIPTION
Reverts ultralytics/handbook#247

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the docs site’s language switching behavior and chat widget handling for a smoother, more reliable user experience. 🌍💬

---

### 📊 Key Changes
- 💬 **Chat widget instance stored globally**  
  - Introduces a `_ultralyticsChat` variable and assigns the `UltralyticsChat` instance to it for potential future control or extensions.

- 🌐 **Language switcher logic simplified and hardened**  
  - Removes custom code that dynamically built a language selector in JavaScript.  
  - Adds a new `fixLanguageLinks()` function that:
    - Detects all existing language links (`.md-select__link`) on the page.
    - Automatically infers language codes and current language from the URL.
    - Correctly rewrites language links so they always point to the equivalent page in each language (including the default language).

- 🔁 **Better handling of SPA-style navigation**  
  - For MkDocs Material (with `document$`), re-applies language link fixes after internal page navigations.
  - For non-MkDocs SPA-like navigation, adds a lightweight `setInterval` path watcher that re-runs `fixLanguageLinks()` when the URL path changes.

- ⚙️ **MkDocs configuration updated for multilingual support**  
  - Adds an `extra.alternate` section in `mkdocs.yml` defining:
    - 🇬🇧 English (`/`, `en`)
    - 🇨🇳 简体中文 (`/zh/`, `zh`)
    - 🇪🇸 Español (`/es/`, `es`)
  - Aligns configuration with MkDocs Material’s built‑in language/alternate URL handling.

---

### 🎯 Purpose & Impact
- 🌍 **More reliable language switching**  
  - Users are taken to the same page in another language instead of being redirected incorrectly or back to the home page.
  - Works more robustly across different navigation patterns (full page loads and SPA-style transitions).

- 🧹 **Cleaner, more maintainable code**  
  - Drops custom DOM-building logic for the language selector and relies on MkDocs’ `alternate` config instead.
  - Centralizes behavior in a single `fixLanguageLinks()` function that is easier to reason about and update.

- 🔧 **Extensibility for the chat widget**  
  - Exposing the `UltralyticsChat` instance via `_ultralyticsChat` makes future enhancements (e.g., programmatically opening, closing, or configuring the chat) easier.

- ✅ **Improved user experience across locales**  
  - Multilingual visitors can switch languages with fewer surprises, leading to a smoother documentation browsing experience on the Ultralytics handbook.