### PR TITLE
Block sitemap fetches

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -7,7 +7,9 @@
   const originalFetch = window.fetch;
   window.fetch = function (url, options) {
     if (typeof url === "string" && url.includes("/sitemap.xml")) {
-      return Promise.resolve(new Response(EMPTY_SITEMAP, { status: 200, headers: { "Content-Type": "application/xml" } }));
+      return Promise.resolve(
+        new Response(EMPTY_SITEMAP, { status: 200, headers: { "Content-Type": "application/xml" } }),
+      );
     }
     return originalFetch.apply(this, arguments);
   };


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Stops unnecessary `sitemap.xml` requests in the docs site by intercepting them and returning a safe, empty sitemap response. 🛑🗺️

### 📊 Key Changes
- ✋ Overrides `window.fetch` to detect any request to `/sitemap.xml` and immediately return an empty sitemap XML with a successful 200 status.
- 🚧 Hooks into `XMLHttpRequest.open` to flag `/sitemap.xml` requests for blocking.
- 📦 Customizes `XMLHttpRequest.send` so flagged sitemap requests never hit the network; instead, they get a mocked 200 response with an empty sitemap (including parsed `responseXML`).
- 🧩 All logic is wrapped in an IIFE to avoid polluting the global namespace and integrates cleanly with existing MkDocs Material + Weglot behavior.

### 🎯 Purpose & Impact
- ⚡ Prevents repeated or unnecessary `sitemap.xml` fetches triggered by Weglot’s hreflang tags and MkDocs Material, reducing network noise and potential performance impact.
- ✅ Ensures the docs site behaves predictably even if `/sitemap.xml` is missing, slow, or misconfigured, by always returning a safe, empty sitemap.
- 🔧 Reduces the risk of console errors, broken UI behavior, or unexpected SEO tooling side effects related to sitemap loading in the docs environment.