### PR TITLE
Refactor fetch and XMLHttpRequest to block sitemap.xml

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -1,13 +1,42 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 // Block sitemap.xml fetches triggered by Weglot's hreflang tags detected by MkDocs Material
-((originalFetch) => {
+(() => {
   const EMPTY_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`;
-  window.fetch = (url, options) =>
-    typeof url === "string" && url.includes("/sitemap.xml")
-      ? Promise.resolve(new Response(EMPTY_SITEMAP, { status: 200, headers: { "Content-Type": "application/xml" } }))
-      : originalFetch.call(window, url, options);
-})(window.fetch);
+
+  const originalFetch = window.fetch;
+  window.fetch = function (url, options) {
+    if (typeof url === "string" && url.includes("/sitemap.xml")) {
+      return Promise.resolve(
+        new Response(EMPTY_SITEMAP, { status: 200, headers: { "Content-Type": "application/xml" } }),
+      );
+    }
+    return originalFetch.apply(this, arguments);
+  };
+
+  const originalXHROpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (method, url) {
+    if (typeof url === "string" && url.includes("/sitemap.xml")) {
+      this._blockRequest = true;
+    }
+    return originalXHROpen.apply(this, arguments);
+  };
+
+  const originalXHRSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function () {
+    if (this._blockRequest) {
+      Object.defineProperty(this, "status", { value: 200 });
+      Object.defineProperty(this, "responseText", { value: EMPTY_SITEMAP });
+      Object.defineProperty(this, "response", { value: EMPTY_SITEMAP });
+      Object.defineProperty(this, "responseXML", {
+        value: new DOMParser().parseFromString(EMPTY_SITEMAP, "application/xml"),
+      });
+      this.dispatchEvent(new Event("load"));
+      return;
+    }
+    return originalXHRSend.apply(this, arguments);
+  };
+})();
 
 // Apply theme colors based on dark/light mode
 const applyTheme = (isDark) => {


### PR DESCRIPTION
Refactor sitemap.xml fetch blocking logic for better clarity and functionality.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enhances the handbook site’s JavaScript to safely block unwanted `sitemap.xml` requests across both `fetch` and XMLHttpRequest, improving compatibility and stability with third‑party tools like Weglot. 🚀

---

### 📊 Key Changes
- 🔧 Refactors the existing `fetch` override into a self-contained function that:
  - Stores the original `window.fetch`
  - Intercepts calls to `/sitemap.xml` and returns an empty sitemap response
  - Uses `originalFetch.apply(this, arguments)` to better preserve context and arguments
- 🛡️ Adds equivalent blocking logic for `XMLHttpRequest`:
  - Overrides `XMLHttpRequest.prototype.open` to flag `/sitemap.xml` requests
  - Overrides `XMLHttpRequest.prototype.send` to:
    - Short-circuit flagged requests
    - Set status, `responseText`, `response`, and `responseXML` to an empty sitemap
    - Dispatch a `"load"` event so listeners behave as if the request succeeded
- ✅ Keeps the returned sitemap XML valid but empty to satisfy consumers expecting a well-formed XML response.

---

### 🎯 Purpose & Impact
- 🌍 Prevents unnecessary or problematic `sitemap.xml` requests triggered by Weglot’s hreflang tags in MkDocs Material, reducing noise and potential errors.
- 🔒 Makes the blocking behavior more robust by covering **both** `fetch` and `XMLHttpRequest`, ensuring all typical network paths are handled.
- 🤝 Improves compatibility with third-party scripts and plugins that might use different request methods, leading to fewer console errors and more reliable docs behavior.
- 🧪 Maintains expected browser APIs and events (like `"load"`), minimizing the risk of breaking existing code that listens for network responses.