### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - name: Install dependencies
         run: |
           uv pip install --system -r requirements.txt mkdocs mkdocs-material


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping the handbook repository’s automation up to date.

### 📊 Key Changes
- Upgraded the CI workflow dependency from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8` in `.github/workflows/ci.yml`.
- No application code, documentation content, or user-facing features were changed.
- The update only affects the automated environment setup used during CI runs. ⚙️

### 🎯 Purpose & Impact
- Helps keep the repository aligned with the latest supported version of the `setup-uv` GitHub Action. 🚀
- May improve CI reliability, compatibility, and maintenance by using a newer action release.
- Reduces the risk of issues tied to older workflow dependencies, with minimal impact on contributors or end users. ✅