### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - name: Install dependencies
         run: |
           uv pip install --system -r requirements.txt mkdocs mkdocs-material


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping the handbook’s automation tooling current.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action in `.github/workflows/ci.yml`
- Changed:
  - `astral-sh/setup-uv@v7` → `astral-sh/setup-uv@v8`
- No changes were made to handbook content, build commands, or Python version settings

### 🎯 Purpose & Impact
- Keeps CI aligned with the latest supported version of the `uv` setup action 🚀
- May improve workflow reliability, compatibility, and access to upstream fixes
- Helps reduce maintenance risk by avoiding older action versions 🛠️
- Has minimal user-facing impact, but supports smoother automated checks and documentation builds behind the scenes 📚