### PR TITLE
Remove trailing sign-offs from handbook pages

### DIFF
--- a/docs/en/contributions/community-engagement.md
+++ b/docs/en/contributions/community-engagement.md
@@ -144,7 +144,3 @@ We recognize outstanding community members through:
 ## Get Involved Today! 🚀
 
 The strength of Ultralytics comes from our community. Whether you're answering questions, contributing code, or sharing your projects, every contribution matters. Join us in advancing computer vision and AI for everyone.
-
----
-
-_Together, we're building the future of AI. Thank you for being part of the Ultralytics community! 🎯_

--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -473,7 +473,3 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
     2. **Ask your manager**: First point of contact for most questions
     3. **Contact specialized teams**: IT, Finance, Legal, Security
     4. **Check documentation**: [YOLO Docs](https://docs.ultralytics.com/) for technical questions
-
----
-
-_This FAQ is continuously updated. Have a question that should be added? Contact your manager or submit a handbook improvement PR!_

--- a/docs/en/finance/index.md
+++ b/docs/en/finance/index.md
@@ -103,7 +103,3 @@ Employees are encouraged to proactively manage departmental budgets responsibly:
     | **Budget Questions** | Your direct manager |
     | **Policy Clarification** | Finance team |
     | **Urgent Issues** | Contact your manager immediately |
-
----
-
-_Stay tuned as we continue to expand the Ultralytics Finance Handbook to support our growing organization effectively._ 🚀

--- a/docs/en/finance/relocation.md
+++ b/docs/en/finance/relocation.md
@@ -174,7 +174,3 @@ If you leave Ultralytics voluntarily within 24 months of your relocation/payment
     | **Eligibility/Commute Check** | HR Team |
     | **Payment Status** | Finance Team |
     | **Tax Questions** | External tax advisor |
-
----
-
-_This policy is designed to support the strategic growth of Ultralytics by helping our team live comfortably close to where we innovate._

--- a/docs/en/goals/company-goals.md
+++ b/docs/en/goals/company-goals.md
@@ -98,7 +98,3 @@ graph LR
     | **Monthly Business Reviews** | Leadership | Monthly |
     | **Quarterly Board Updates** | Investors & advisors | Quarterly |
     | **Public Metrics** | Community | Ongoing |
-
----
-
-_Detailed goals and metrics are reviewed internally. See [OKRs](okrs.md) for our goal-setting framework._

--- a/docs/en/goals/okrs.md
+++ b/docs/en/goals/okrs.md
@@ -129,7 +129,3 @@ OKRs are managed through:
 - Weekly team standups
 - Progress tracking dashboards
 - Leadership review meetings
-
----
-
-_For questions about OKRs, contact your manager or see [Company Goals](company-goals.md) for strategic priorities._

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -322,7 +322,3 @@ graph LR
 !!! tip "Make an Impact"
 
     Your contributions help improve the experience for everyone at Ultralytics. Whether it's fixing a typo or adding a new section, every improvement counts!
-
----
-
-**Happy reading and contributing!** Together, we're building the future of AI. Explore [career opportunities](https://www.ultralytics.com/careers) or read about [our latest updates](https://www.ultralytics.com/blog). 🌟

--- a/docs/en/people/careers/index.md
+++ b/docs/en/people/careers/index.md
@@ -206,7 +206,3 @@ Compensation reflects scope, impact, and market rates—not tenure. Both tracks 
 - **[Management Levels (M4-M10)](levels-management.md)** - Detailed Management expectations
 - **[People & Benefits](../index.md)** - Comprehensive people policies and resources
 - **[Onboarding](../onboarding.md)** - Level expectations for new team members
-
----
-
-_Your career at Ultralytics is a journey, not a destination. We're committed to supporting your growth whether you aspire to deep expertise or organizational leadership. Let's build amazing things together! 🚀_

--- a/docs/en/people/careers/levels-ic.md
+++ b/docs/en/people/careers/levels-ic.md
@@ -522,7 +522,3 @@ Create targeted growth plans:
 - **[Career Progression](../index.md)** - Complete framework, promotion process, track switching
 - **[People & Benefits](../../index.md)** - Comprehensive people policies and resources
 - **[Onboarding](../onboarding.md)** - Level expectations for new team members
-
----
-
-_These level descriptions are living documents that evolve as Ultralytics grows. Feedback and improvements welcome through PRs or discussions with your manager._

--- a/docs/en/people/careers/levels-management.md
+++ b/docs/en/people/careers/levels-management.md
@@ -574,7 +574,3 @@ Strong promotion cases include:
 - **[Career Progression](index.md)** - Complete framework, promotion process, track switching
 - **[People & Benefits](../index.md)** - Comprehensive people policies and resources
 - **[Onboarding](../onboarding.md)** - Management expectations for new managers
-
----
-
-_Great management empowers teams to do their best work. These frameworks ensure we develop leaders who build high-performing, engaged, and growing teams. Leadership is a skill learned through practice, feedback, and continuous improvement._

--- a/docs/en/people/index.md
+++ b/docs/en/people/index.md
@@ -221,7 +221,3 @@ Can't find what you're looking for?
 - **Ask your manager** for policy clarifications or personal matters
 - **Contact HR** for benefits, leave, or employee relations
 - **Submit a PR** to improve this handbook for everyone
-
----
-
-_We're committed to creating an environment where everyone can do their best work and grow their careers. Welcome to the team! 🌟_

--- a/docs/en/people/onboarding.md
+++ b/docs/en/people/onboarding.md
@@ -386,7 +386,3 @@ Have onboarding feedback or questions?
 - **Email HR**: For sensitive or personal matters
 
 We're constantly improving onboarding based on new team member feedback. Your input makes the next person's experience better!
-
----
-
-_Welcome to the team! We're excited to have you here. Let's build something amazing together! 🚀_

--- a/docs/en/tools/email-signatures.md
+++ b/docs/en/tools/email-signatures.md
@@ -129,7 +129,3 @@ The automation is implemented in Python and utilizes the following:
 ## 7. Support and Maintenance 🛠️
 
 The email signature automation is maintained by Glenn Jocher. If you have any questions or encounter any issues with your email signature, please contact him for assistance.
-
----
-
-_Standardized email signatures ensure consistent professional communication across all Ultralytics correspondence. 🚀_

--- a/docs/en/tools/hardware.md
+++ b/docs/en/tools/hardware.md
@@ -397,7 +397,3 @@ graph TD
     - Include clear description of business purpose
     - For detailed procedures, see [Finance Handbook](../finance/index.md)
     - Reimbursements typically processed within 7 business days
-
----
-
-_This policy ensures consistent, secure, and cost-effective hardware provisioning, empowering our global team to achieve its best work. 🚀_

--- a/docs/en/tools/software.md
+++ b/docs/en/tools/software.md
@@ -194,7 +194,3 @@ Our team prioritizes requests to ensure critical issues are handled swiftly.
 - **Critical (System-wide outage, security breach):** 1-hour response
 - **High (Individual unable to work):** 4-hour response
 - **Normal (Minor issue, software request):** 24-hour response
-
----
-
-_This policy helps us maintain a secure, compliant, and productive software environment. For any questions, please contact your manager or the Security team._


### PR DESCRIPTION
## Summary
- remove trailing italic sign-off blurbs from handbook pages that ended with decorative footer copy
- remove the matching horizontal rule so pages now end on the actual content

## Testing
- CI=1 npm run build

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR cleans up the Ultralytics handbook by removing closing divider lines and informal sign-off messages from multiple documentation pages for a more consistent, streamlined look.

### 📊 Key Changes
- Removed footer-style endings from many handbook pages across:
  - Community contributions
  - FAQ
  - Finance
  - Relocation
  - Company goals and OKRs
  - Main handbook index
  - Careers and leveling guides
  - People and onboarding
  - Tools, hardware, software, and email signatures
- Deleted repeated markdown separators like `---` at the ends of documents.
- Removed motivational or closing italicized messages such as “thank you,” “stay tuned,” and similar sign-offs.
- Kept the main policy and guidance content unchanged ✅

### 🎯 Purpose & Impact
- Improves documentation consistency across the handbook 📘
- Makes pages feel cleaner and more professional by removing repetitive end notes ✨
- Reduces visual clutter so readers can focus on the actual policies and guidance 👀
- Has no functional or policy impact; this is a presentation and formatting cleanup only 🔧
- Helps maintain a more standardized documentation style as the handbook grows 🚀