### PR TITLE
Update Ultralytics Platform references

### DIFF
--- a/docs/en/workflows/development.md
+++ b/docs/en/workflows/development.md
@@ -22,7 +22,7 @@ All contributors must follow the [Code of Conduct](https://docs.ultralytics.com/
 
 ## Scope and Ownership 🧭
 
-This workflow applies to Ultralytics engineering work across product, platform, YOLO, HUB, infrastructure, documentation, automation, and security-sensitive systems. Individual repositories may add stricter requirements, but they should not weaken the baseline expectations in this page.
+This workflow applies to Ultralytics engineering work across product, [Ultralytics Platform](https://platform.ultralytics.com), YOLO, infrastructure, documentation, automation, and security-sensitive systems. Individual repositories may add stricter requirements, but they should not weaken the baseline expectations in this page.
 
 Every work item should have a clear owner:
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -29,7 +29,7 @@
       alt="Ultralytics"
       class="banner-logo"
     />
-    <p>Introducing Ultralytics Platform: Annotate, train, and deploy YOLO models</p>
+    <p>Introducing Ultralytics Platform: Annotate, train, deploy, and monitor production YOLO models</p>
   </div>
   <img
     src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/69ba5bb596507e4235390de5_banner-arrow-right.png"


### PR DESCRIPTION
## Summary
- replace the remaining product-scope HUB wording with Ultralytics Platform and link it to https://platform.ultralytics.com
- update the announcement banner copy to match current Platform positioning around annotation, training, deployment, and monitoring

## Audit
- searched tracked files for `HUB`, `Ultralytics HUB`, `Ultralytics Hub`, `hub.ultralytics.com`, and `ultralytics.com/hub`
- remaining word-level `hub` matches are unrelated workplace/internal/Docker Hub references

## Tests
- `CI=1 npm run build`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates handbook wording to better reflect the **Ultralytics Platform** and its role in the development workflow and product messaging 🚀

### 📊 Key Changes
- Replaced the older reference to **HUB** in the development workflow docs with **[Ultralytics Platform](https://platform.ultralytics.com)**.
- Updated the workflow scope text to clarify that engineering standards apply across product, **Ultralytics Platform**, YOLO, infrastructure, documentation, automation, and security-sensitive systems.
- Revised the site banner message from:
  - “Annotate, train, and deploy YOLO models”
  to:
  - “Annotate, train, deploy, and monitor production YOLO models” 📈
- Improved product positioning in the docs by emphasizing **production monitoring** as part of the platform experience.

### 🎯 Purpose & Impact
- Helps keep documentation aligned with current **Ultralytics branding and platform terminology** 🏷️
- Makes it clearer to contributors and readers that **Ultralytics Platform** is the active product name and part of core engineering workflows.
- Better communicates the platform’s broader value, especially for users managing **production YOLO deployments** 🔍
- Improves consistency across the handbook and website messaging, reducing confusion for both new and existing users ✅