### PR TITLE
Fix admonition bullet indentation

### DIFF
--- a/docs/en/mission-vision-values/index.md
+++ b/docs/en/mission-vision-values/index.md
@@ -96,9 +96,9 @@ We work where the speed is. Our computer vision breakthroughs demand high-bandwi
 
 !!! tip "Why In-Person Wins"
 
-- **Speed:** Live decisions beat async threads when stakes are high.
-- **Clarity:** Whiteboards, labs, and shared context cut ambiguity.
-- **Growth:** Shoulder-to-shoulder mentoring accelerates skills and visibility.
+    - **Speed:** Live decisions beat async threads when stakes are high.
+    - **Clarity:** Whiteboards, labs, and shared context cut ambiguity.
+    - **Growth:** Shoulder-to-shoulder mentoring accelerates skills and visibility.
 
 ## Living Our Values 🤝
 

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -211,6 +211,9 @@ prateek@ultralytics.com:
 priytosh.revolution@live.com:
   avatar: https://avatars.githubusercontent.com/u/19519529?v=4
   username: priytosh-tripathi
+raimbekov_m@auca.kg:
+  avatar: https://avatars.githubusercontent.com/u/144048515?v=4
+  username: raimbekovm
 rulosanti@gmail.com:
   avatar: null
   username: null


### PR DESCRIPTION
## Summary
- Indent the "Why In-Person Wins" bullets so they render inside the tip admonition.
- Retain the generated GitHub authors cache update from the docs build.
- Audited all 208 Markdown admonitions for malformed or empty bodies; no other escaped admonition content found.

## Validation
- Custom admonition structure audit: 208 admonitions checked, 0 malformed first body lines, 0 empty admonitions.
- git diff --check
- python -m zensical build --strict
- CI=1 npm run build

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes a small documentation cleanup by fixing list formatting in the mission/vision/values page and adding a new GitHub author mapping for docs attribution.

### 📊 Key Changes
- ✅ Fixed indentation for the bullet list under **“Why In-Person Wins”** in `docs/en/mission-vision-values/index.md`
  - This likely ensures the list renders correctly inside the MkDocs/admonition tip block.
- 👤 Added a new entry to `docs/mkdocs_github_authors.yaml`
  - Mapped `raimbekov_m@auca.kg` to GitHub user @raimbekovm
  - Included the user’s GitHub avatar URL for proper author display in docs metadata.

### 🎯 Purpose & Impact
- 📚 Improves documentation presentation by making sure nested bullets display cleanly and consistently.
- 🛠️ Prevents formatting issues in the rendered docs, which helps readers better understand the content.
- 🙌 Expands author attribution support so contributions from @raimbekovm can be correctly recognized in the documentation site.
- 🌍 Overall impact is small but positive: better polish, clearer docs, and more complete contributor metadata.