### PR TITLE
Update hardware policy to M5 MacBook Air

### DIFF
--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -140,7 +140,7 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
 
         ---
 
-        - **MacBook Air** (13", M4, 16GB RAM, 256GB)
+        - **MacBook Air** (13", M5, 16GB RAM, 512GB)
         - **MacBook Pro** (14", M5, 16GB RAM, 512GB) for technical roles
 
     -   :material-headphones: **Audio**

--- a/docs/en/tools/hardware.md
+++ b/docs/en/tools/hardware.md
@@ -46,7 +46,7 @@ timeline
 
     ***
 
-    [13", M4, 16GB RAM, 256GB Storage](https://www.apple.com/macbook-air/)
+    [13", M5, 16GB RAM, 512GB Storage](https://www.apple.com/macbook-air/)
 
     **Default for all employees**
 


### PR DESCRIPTION
## Summary
- update the Handbook hardware policy MacBook Air standard config from M4/256GB to M5/512GB
- update the matching FAQ equipment answer
- leave management-level M4/M5 career references unchanged

## Apple source check
- MacBook Air: https://www.apple.com/macbook-air/ and https://support.apple.com/en-us/126320 show M5, 16GB unified memory, and 512GB SSD
- MacBook Pro: https://support.apple.com/en-us/125405 shows 14-inch M5 with 16GB/24GB/32GB unified memory and 512GB or 1TB SSD

## Validation
- python -m zensical build --strict
- CI=1 npm run build
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR updates Ultralytics handbook hardware docs to reflect a newer default employee laptop configuration: the 13-inch MacBook Air now uses an M5 chip and 512GB storage.

### 📊 Key Changes
- Updated the default **MacBook Air** spec in the FAQ from:
  - **M4, 16GB RAM, 256GB**
  - to **M5, 16GB RAM, 512GB** 💻
- Updated the same **MacBook Air** specification in the hardware tools page to keep documentation consistent 🔄
- No changes were made to the **MacBook Pro** option for technical roles

### 🎯 Purpose & Impact
- Ensures the handbook reflects the latest approved employee hardware standards ✅
- Gives new hires and team members clearer, more accurate expectations about default equipment 🎯
- Improves consistency across internal documentation, reducing confusion and outdated references 📚
- Signals a better baseline device offering, with newer hardware and more storage for everyday work 🚀