### PR TITLE
Remove Weglot handbook overrides

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -1,43 +1,5 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-// Block sitemap.xml fetches triggered by Weglot's hreflang tags detected by MkDocs Material
-(() => {
-  const EMPTY_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`;
-
-  const originalFetch = window.fetch;
-  window.fetch = function (url, options) {
-    if (typeof url === "string" && url.includes("/sitemap.xml")) {
-      return Promise.resolve(
-        new Response(EMPTY_SITEMAP, { status: 200, headers: { "Content-Type": "application/xml" } }),
-      );
-    }
-    return originalFetch.apply(this, arguments);
-  };
-
-  const originalXHROpen = XMLHttpRequest.prototype.open;
-  XMLHttpRequest.prototype.open = function (method, url) {
-    if (typeof url === "string" && url.includes("/sitemap.xml")) {
-      this._blockRequest = true;
-    }
-    return originalXHROpen.apply(this, arguments);
-  };
-
-  const originalXHRSend = XMLHttpRequest.prototype.send;
-  XMLHttpRequest.prototype.send = function () {
-    if (this._blockRequest) {
-      Object.defineProperty(this, "status", { value: 200 });
-      Object.defineProperty(this, "responseText", { value: EMPTY_SITEMAP });
-      Object.defineProperty(this, "response", { value: EMPTY_SITEMAP });
-      Object.defineProperty(this, "responseXML", {
-        value: new DOMParser().parseFromString(EMPTY_SITEMAP, "application/xml"),
-      });
-      this.dispatchEvent(new Event("load"));
-      return;
-    }
-    return originalXHRSend.apply(this, arguments);
-  };
-})();
-
 // Apply theme colors based on dark/light mode
 const applyTheme = (isDark) => {
   document.body.setAttribute("data-md-color-scheme", isDark ? "slate" : "default");

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -243,11 +243,3 @@ table td:nth-child(2):last-child {
 .md-typeset a {
   text-decoration: none;
 }
-
-/* Global kill-switch for Weglot UI */
-.weglot-container,
-.weglot_switcher,
-[id^="weglot-switcher"],
-.weglot-container[id^="weglot-switcher"] {
-  display: none;
-}


### PR DESCRIPTION
## Summary
- remove the old Weglot switcher CSS kill-switch from handbook styles
- remove the Weglot sitemap request shim from handbook JavaScript overrides

## Tests
- `rg -n "Weglot|weglot|WEGLOT|weglot-container|weglot_switcher|weglot-switcher" docs/overrides -S` (no matches)
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR removes custom Weglot-related request blocking and UI-hiding code from the handbook docs overrides, simplifying the frontend setup.

### 📊 Key Changes
- Removed JavaScript in `docs/overrides/javascript/extra.js` that intercepted `fetch` and `XMLHttpRequest` calls to block `/sitemap.xml` requests.
- Deleted the logic that returned a fake empty sitemap response for those blocked requests.
- Removed CSS in `docs/overrides/stylesheets/style.css` that globally hid Weglot translation UI elements.
- Kept the rest of the docs theme behavior unchanged, including dark/light mode theme handling.

### 🎯 Purpose & Impact
- ✨ Simplifies the docs frontend by removing workaround code that patched browser network behavior.
- 🔧 Reduces maintenance burden and lowers the risk of side effects from overriding `fetch` and `XMLHttpRequest`.
- 🌐 Allows Weglot-related sitemap requests and UI elements to behave normally again, likely reflecting an updated translation or docs setup.
- 📉 Makes debugging easier since the site no longer masks requests with synthetic responses or force-hides translation controls.