### PR TITLE
Fix dead contributor link: tthakz → t-hakobyan

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -234,7 +234,7 @@ thunderbirdtr@gmail.com:
   username: onuralpszr
 tigran@ultralytics.com:
   avatar: https://avatars.githubusercontent.com/u/197762997?v=4
-  username: tthakz
+  username: t-hakobyan
 waxmann.sergiu@me.com:
   avatar: https://avatars.githubusercontent.com/u/47978446?v=4
   username: sergiuwaxmann


### PR DESCRIPTION
## Summary

Link-check flagged a 404 on `https://github.com/tthakz` (linked from the [How to Contribute](https://handbook.ultralytics.com/contributions/how-to-contribute) contributors list).

The GitHub account `197762997` (`tigran@ultralytics.com`) renamed from **tthakz** → **t-hakobyan**, so the cached author username in `docs/mkdocs_github_authors.yaml` was stale. The numeric avatar ID is unchanged.

## Verification

```
github.com/tthakz      → 404
github.com/t-hakobyan  → 200  (id 197762997)
```

Single-line change to the author cache; the contributor's avatar and attribution are otherwise unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the GitHub author mapping for one Ultralytics contributor to correct their linked username and profile identity 🔧

### 📊 Key Changes
- Changed the GitHub username for `tigran@ultralytics.com` in `docs/mkdocs_github_authors.yaml`
- Replaced the old username `tthakz` with the corrected username `t-hakobyan`
- Kept the existing avatar entry unchanged, updating only the author-to-GitHub account mapping

### 🎯 Purpose & Impact
- Ensures the correct contributor is credited in handbook documentation and author listings ✅
- Improves accuracy of contributor metadata used by the docs site 🧾
- Helps readers and team members identify and link to the right GitHub profile more reliably 🔗
- Low-risk change with no effect on product features or documentation content itself 👍