### PR TITLE
Use blobless checkout in tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none # full commit/tag history for describe/log without historical file blobs
           token: ${{ secrets._GITHUB_TOKEN }}
 
       - name: Git config


### PR DESCRIPTION
## Why

The Tag and Release workflow checks out with `fetch-depth: 0` (full history, all blobs) to run a handful of metadata-only git commands: `git rev-parse <tag>`, `git tag -a -m "$(git log -1 --pretty=%B)"`, `git push origin <tag>`, plus `git describe`/`git rev-list` inside `ultralytics-actions-summarize-release`. The release diff and PR list come from the GitHub API compare endpoint, not local git, so no file blobs are ever read.

## What

Adds `filter: blob:none` to the checkout: full commit and tag history is retained (required for describe/log/rev-list), only blob downloads are skipped. Same change as ultralytics/docs#314, where the gh-pages-heavy checkout drops from ~2.1 GB / 141 s to ~55 MB / 4-5 s; here the win is smaller but the workflow semantics are identical and verified the same way.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚙️ This PR optimizes the release tagging workflow by making Git checkout more efficient while still preserving the full commit and tag history needed for versioning tasks.

### 📊 Key Changes
- Added `filter: blob:none` to the checkout step in `.github/workflows/tag.yml`.
- Keeps `fetch-depth: 0`, so the workflow still has full commit and tag history.
- Prevents downloading historical file contents that are not needed for `git describe` or `git log` during tagging.

### 🎯 Purpose & Impact
- 🚀 Speeds up the tagging workflow by reducing the amount of data fetched during checkout.
- 📉 Lowers bandwidth and storage usage in GitHub Actions runs.
- 🏷️ Preserves correct tag/version resolution, since commit and tag history remain available.
- ✅ Improves CI efficiency with minimal risk, as the workflow behavior stays the same for tagging-related operations.