### PR TITLE
Trigger Portal handbook redeploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,30 @@ jobs:
           uv pip install --system -r requirements.txt mkdocs mkdocs-material
       - name: Build docs (warnings as errors)
         run: mkdocs build --strict
+      - name: Check handbook source changes
+        id: handbook_changes
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            BEFORE_SHA="$(git rev-list --max-parents=0 "$CURRENT_SHA")"
+          fi
+
+          if git diff --quiet "$BEFORE_SHA" "$CURRENT_SHA" -- docs mkdocs.yml mkdocs.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Trigger Portal handbook redeploy
+        if: github.event_name == 'push' && steps.handbook_changes.outputs.changed == 'true'
+        env:
+          VERCEL_HANDBOOK_DEPLOY_HOOK: ${{ secrets.VERCEL_HANDBOOK_DEPLOY_HOOK }}
+        run: |
+          if [[ -z "$VERCEL_HANDBOOK_DEPLOY_HOOK" ]]; then
+            echo "::error::VERCEL_HANDBOOK_DEPLOY_HOOK is not configured"
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --retry 3 --request POST "$VERCEL_HANDBOOK_DEPLOY_HOOK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,18 @@ jobs:
           CURRENT_SHA: ${{ github.sha }}
         run: |
           if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
-            BEFORE_SHA="$(git rev-list --max-parents=0 "$CURRENT_SHA")"
+            changed_files="$(git diff-tree --no-commit-id --name-only -r "$CURRENT_SHA")"
+          else
+            if ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "$BEFORE_SHA"
+            fi
+            changed_files="$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")"
           fi
 
-          if git diff --quiet "$BEFORE_SHA" "$CURRENT_SHA" -- docs mkdocs.yml mkdocs.yaml; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
+          if grep -Eq '^(docs/|mkdocs\.ya?ml$)' <<< "$changed_files"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Trigger Portal handbook redeploy
         if: github.event_name == 'push' && steps.handbook_changes.outputs.changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,35 +27,15 @@ jobs:
           uv pip install --system -r requirements.txt mkdocs mkdocs-material
       - name: Build docs (warnings as errors)
         run: mkdocs build --strict
-      - name: Check handbook source changes
-        id: handbook_changes
+      - name: Trigger Portal handbook redeploy
         if: github.event_name == 'push'
         env:
-          BEFORE_SHA: ${{ github.event.before }}
-          CURRENT_SHA: ${{ github.sha }}
-        run: |
-          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
-            changed_files="$(git diff-tree --no-commit-id --name-only -r "$CURRENT_SHA")"
-          else
-            if ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "$BEFORE_SHA"
-            fi
-            changed_files="$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")"
-          fi
-
-          if grep -Eq '^(docs/|mkdocs\.ya?ml$)' <<< "$changed_files"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Trigger Portal handbook redeploy
-        if: github.event_name == 'push' && steps.handbook_changes.outputs.changed == 'true'
-        env:
           VERCEL_HANDBOOK_DEPLOY_HOOK: ${{ secrets.VERCEL_HANDBOOK_DEPLOY_HOOK }}
+          CHANGED_FILES: ${{ toJson(github.event.commits.*.added) }} ${{ toJson(github.event.commits.*.modified) }} ${{ toJson(github.event.commits.*.removed) }}
         run: |
-          if [[ -z "$VERCEL_HANDBOOK_DEPLOY_HOOK" ]]; then
-            echo "::error::VERCEL_HANDBOOK_DEPLOY_HOOK is not configured"
-            exit 1
+          if ! grep -Eq 'docs/|mkdocs\.ya?ml' <<< "$CHANGED_FILES"; then
+            echo "No handbook source changes."
+            exit 0
           fi
 
           curl --fail --silent --show-error --retry 3 --request POST "$VERCEL_HANDBOOK_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- detect merged handbook source changes in the existing docs CI workflow
- POST the Portal handbook Vercel deploy hook after docs/mkdocs changes land on main
- keep PR events as build/check only; production redeploy happens on the merged main push

## Required secret
- `VERCEL_HANDBOOK_DEPLOY_HOOK`: Vercel deploy hook URL for the Portal `handbook` project

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check -- .github/workflows/ci.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds CI logic to detect handbook source changes on push events and automatically trigger a Portal handbook redeploy only when relevant docs files are updated. 🚀

### 📊 Key Changes
- Adds a new CI step to check for changes between the previous and current commit in `docs`, `mkdocs.yml`, and `mkdocs.yaml`.
- Handles first-push edge cases by falling back to the repository root commit when `github.event.before` is all zeros.
- Exposes a `changed` output from the handbook change detection step for downstream workflow logic.
- Adds a conditional redeploy step that posts to the `VERCEL_HANDBOOK_DEPLOY_HOOK` secret only when handbook source files have changed.
- Fails clearly if the deploy hook secret is missing, improving workflow visibility and reliability. ⚙️

### 🎯 Purpose & Impact
- Reduces unnecessary Portal handbook redeploys by triggering them only for actual documentation-related changes. 📚
- Improves deployment efficiency and lowers noise in the release pipeline.
- Keeps the Portal handbook in sync with repository updates more reliably after pushes.
- Adds safer automation with explicit secret validation and retry behavior for the deploy request. ✅