### PR TITLE
Fix handbook deploy change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -31,11 +33,17 @@ jobs:
         if: github.event_name == 'push'
         env:
           VERCEL_HANDBOOK_DEPLOY_HOOK: ${{ secrets.VERCEL_HANDBOOK_DEPLOY_HOOK }}
-          CHANGED_FILES: ${{ toJson(github.event.commits.*.added) }} ${{ toJson(github.event.commits.*.modified) }} ${{ toJson(github.event.commits.*.removed) }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
-          if ! grep -Eq 'docs/|mkdocs\.ya?ml' <<< "$CHANGED_FILES"; then
+          if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            BEFORE_SHA=$(git rev-list --max-parents=0 "$CURRENT_SHA")
+          fi
+          changed_files=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- docs/ mkdocs.yml mkdocs.yaml)
+          if [[ -z "$changed_files" ]]; then
             echo "No handbook source changes."
             exit 0
           fi
+          echo "$changed_files"
 
           curl --fail --silent --show-error --retry 3 --request POST "$VERCEL_HANDBOOK_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- detect handbook source changes from the checked-out git push range instead of push payload file arrays
- print matched handbook files before calling the Vercel deploy hook
- preserve the existing docs, mkdocs.yml, and mkdocs.yaml path coverage

## Root cause
- The deploy gate added in #295 used `github.event.commits.*` file arrays, which can be empty on main push events even when the pushed range changes docs files.

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check -- .github/workflows/ci.yml`
- `git diff --name-only 9657085^ 9657085 -- docs/ mkdocs.yml mkdocs.yaml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes handbook deployment checks in CI more reliable by detecting actual file changes with `git diff` instead of relying on GitHub event file lists.

### 📊 Key Changes
- ✅ Updated the GitHub Actions checkout step to use `fetch-depth: 0`, ensuring full git history is available during CI.
- 🔄 Replaced the previous changed-file detection logic based on `github.event.commits` with a git-based comparison using:
  - `github.event.before`
  - `github.sha`
- 🧩 Added special handling for first-push scenarios where the previous commit SHA is all zeros, falling back to the repository’s root commit.
- 📁 Limited change detection specifically to handbook-related files:
  - `docs/`
  - `mkdocs.yml`
  - `mkdocs.yaml`
- 🚫 If no handbook source files changed, the workflow exits early and skips the Vercel deploy hook.
- 📝 Added output of the changed files for better visibility in CI logs.

### 🎯 Purpose & Impact
- 🎯 Ensures deployments are triggered only when handbook content or MkDocs config actually changes.
- 🚀 Reduces unnecessary Vercel deploys, saving CI time and avoiding wasted builds.
- 🛡️ Improves reliability compared to commit-event file lists, which can be incomplete or less accurate in some push scenarios.
- 🌍 Handles edge cases like initial branch pushes more safely, preventing missed or broken deploy checks.
- 👀 Makes CI behavior easier to debug by showing exactly which files triggered a deployment.