### PR TITLE
Restore README badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This Handbook serves as a **living document**, evolving alongside Ultralytics' g
 - **[Vercel](https://vercel.com/)** - Hosting and deployment
 - **[GitHub Actions](https://github.com/features/actions)** - CI/CD automation
 
+The Handbook supports the broader Ultralytics ecosystem, including the core [Ultralytics Python package](https://pypi.org/project/ultralytics/):
+
+[![PyPI - Version](https://img.shields.io/pypi/v/ultralytics?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics/)
+[![Downloads](https://static.pepy.tech/badge/ultralytics)](https://clickpy.clickhouse.com/dashboard/ultralytics)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics/)
+
 ## 🛠️ Installation
 
 To build and develop the Handbook locally, install dependencies:


### PR DESCRIPTION
## Summary
- restores the README badge/backlink lines that were removed in the previous cleanup
- preserves existing working badges unless they are proven broken or misleading

## Validation
- git diff --check
- lychee README.md docs/README.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR updates the Handbook README to better connect it with the broader Ultralytics ecosystem by adding visibility for the core `ultralytics` Python package.

### 📊 Key Changes
- Added a short README section explaining that the Handbook supports the wider Ultralytics ecosystem, including the core [Ultralytics Python package on PyPI](https://pypi.org/project/ultralytics/).
- Introduced package status badges for:
  - 📦 current PyPI version
  - 📥 package download count
  - 🐍 supported Python versions
- Placed these additions near the project overview, improving visibility for readers landing on the repository.

### 🎯 Purpose & Impact
- Helps readers quickly understand that the Handbook is tied to the main Ultralytics package, not just standalone documentation. 🔗
- Makes the README more informative and trustworthy by surfacing key package health signals at a glance. ✅
- Improves discoverability of the `ultralytics` package for new users who may want to install or explore it further. 🚀
- Supports broader ecosystem awareness with a small, low-risk documentation-only change that should not affect code or functionality. 🛠️