### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install lychee
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: blob:none # full commit/tag history for describe/log without historical file blobs


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows in `ultralytics/handbook` to use `actions/checkout@v7` instead of `@v6`, keeping CI and automation up to date.

### 📊 Key Changes
- Updated the checkout step from `actions/checkout@v6` to `actions/checkout@v7` in the main CI workflow 🛠️
- Updated the same checkout action in the link-checking workflow 🔗
- Updated the checkout action in the tagging/release-related workflow 🏷️
- No handbook content or user-facing documentation was changed; this is purely a workflow maintenance update 📁

### 🎯 Purpose & Impact
- Keeps the repository’s GitHub Actions aligned with the latest supported checkout action version ✅
- Helps improve long-term reliability, compatibility, and security of automated workflows 🔐
- Reduces the risk of future issues caused by outdated CI dependencies ⚙️
- Has little to no direct impact on handbook readers, but helps maintain smoother development and release operations for contributors 🚀