### PR TITLE
docs: SEO-consistent page titles (fix too-long + too-short <title>)

### DIFF
--- a/docs/en/contributions/publications.md
+++ b/docs/en/contributions/publications.md
@@ -1,4 +1,5 @@
 ---
+title: Publications Guidelines
 description: Ultralytics publications guidelines covering eligibility criteria and how to submit research papers to the official Ultralytics Publications page.
 keywords: Ultralytics publications, research papers, YOLO publications, publication guidelines, paper submission, computer vision research
 ---

--- a/docs/en/introduction.md
+++ b/docs/en/introduction.md
@@ -1,4 +1,5 @@
 ---
+title: Handbook Introduction
 description: Introduction to the Ultralytics Handbook covering company mission, values, workflows, and operational guidelines for team members and contributors.
 keywords: Ultralytics handbook, company introduction, AI handbook, employee guide, contributor guide, open source handbook
 ---

--- a/docs/en/security/employee-security-compliance-requirements.md
+++ b/docs/en/security/employee-security-compliance-requirements.md
@@ -1,4 +1,5 @@
 ---
+title: Employee Security & Compliance
 description: Ultralytics employee security and compliance requirements covering background checks, mandatory training, performance reviews, and offboarding procedures.
 keywords: Ultralytics security compliance, employee security requirements, mandatory training, GDPR, CCPA, security awareness, Vanta, offboarding
 ---

--- a/docs/en/security/isms.md
+++ b/docs/en/security/isms.md
@@ -1,4 +1,5 @@
 ---
+title: Information Security (ISMS)
 description: Ultralytics Information Security Management System (ISMS) covering ISO 27001 alignment, SOC 2 compliance, security controls, and governance structure.
 keywords: Ultralytics ISMS, information security, ISO 27001, SOC 2, data protection, security controls, compliance, Vanta
 ---


### PR DESCRIPTION
## Summary

Handbook side of the cross-repo effort to fix SEMrush `<title>` issues **consistently across every Ultralytics doc surface** (docs + handbook). Strategy settled via an Opus↔Codex review loop.

**Unified rule:** `<title>` = `{concise, front-loaded title} | Ultralytics` (suffix added by the shared docs renderer); the on-page `<h1>` stays descriptive. They differ only by the suffix → never a duplicate tag; the brand is always present; titles stay in the 30–60 char range.

## Changes — 4 pages with title issues (H1s unchanged)

| Page | H1 (kept) | new `title:` | was |
|---|---|---|---|
| `security/isms.md` | Information Security Management System (ISMS) 🔐 | `Information Security (ISMS)` | too long (>60) |
| `security/employee-security-compliance-requirements.md` | What to Expect: Security & Compliance Requirements for Employees | `Employee Security & Compliance` | too long (>60) |
| `contributions/publications.md` | Publications 📚 | `Publications Guidelines` | too short (<30) |
| `introduction.md` | Introduction | `Handbook Introduction` | too short (<30) |

## Verification

Audited all 34 handbook pages with the shared title rule (same predicate the renderer uses): **0 too-long, 0 too-short, 0 duplicate H1==title.**

## Companion PRs (same unified rule)

- portal#2517 — renderer brand suffix + truncation backstop + shared title audit (**merge last**).
- ultralytics#24888 — docs reference generator + narrative + short-title fixes.
- docs#317 — compare-page H1s.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves handbook documentation metadata by adding explicit page titles to several English docs pages, making them clearer and better organized.

### 📊 Key Changes
- Added a `title` field to the front matter of `docs/en/contributions/publications.md`
- Added a `title` field to the front matter of `docs/en/introduction.md`
- Added a `title` field to the front matter of `docs/en/security/employee-security-compliance-requirements.md`
- Added a `title` field to the front matter of `docs/en/security/isms.md`
- New titles introduced:
  - `Publications Guidelines`
  - `Handbook Introduction`
  - `Employee Security & Compliance`
  - `Information Security (ISMS)`

### 🎯 Purpose & Impact
- 📚 Makes handbook pages easier to identify and navigate for readers
- 🔍 Improves documentation structure and likely helps with search, SEO, and page indexing
- 🧭 Creates more consistent metadata across the handbook, which can improve site rendering and discoverability
- 🛠️ Low-risk documentation-only change with no effect on product code or user-facing functionality beyond clearer page labeling