### PR TITLE
Update GitHub author metadata

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -152,8 +152,8 @@ glenn.jocher@ultralytics.com:
   avatar: https://avatars.githubusercontent.com/u/26833433?v=4
   username: glenn-jocher
 hnliu_2@stu.xidian.edu.cn:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/41246950?v=4
+  username: lunarifish
 jin@ultralytics.com:
   avatar: https://avatars.githubusercontent.com/u/4847103?v=4
   username: laodouya
@@ -161,11 +161,11 @@ job@laodouya.com:
   avatar: https://avatars.githubusercontent.com/u/4847103?v=4
   username: laodouya
 jpedrofonseca_94@hotmail.com:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/11836470?v=4
+  username: Jpfonseca
 k-2feng@hotmail.com:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/2324213?v=4
+  username: darouwan
 kontrikova.z@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/212558947?v=4
   username: zkontri
@@ -215,8 +215,8 @@ raimbekov_m@auca.kg:
   avatar: https://avatars.githubusercontent.com/u/144048515?v=4
   username: raimbekovm
 rulosanti@gmail.com:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/20377209?v=4
+  username: rulosant
 shuai.lyu@foxmail.com:
   avatar: https://avatars.githubusercontent.com/u/31230805?v=4
   username: ShuaiLYU
@@ -224,8 +224,8 @@ shuizhuyuanluo@126.com:
   avatar: https://avatars.githubusercontent.com/u/171016?v=4
   username: nihui
 sometimesocrazy@gmail.com:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/5876946?v=4
+  username: maycuatroi1
 stormsson@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/1133032?v=4
   username: stormsson


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR updates the handbook’s GitHub author metadata by filling in missing usernames and avatar links for several contributors.

### 📊 Key Changes
- Added GitHub profile details for previously incomplete author entries in `docs/mkdocs_github_authors.yaml`.
- Replaced `null` values with valid `avatar` URLs and `username` fields for:
  - `hnliu_2@stu.xidian.edu.cn` → @lunarifish
  - `jpedrofonseca_94@hotmail.com` → @Jpfonseca
  - `k-2feng@hotmail.com` → @darouwan
  - `rulosanti@gmail.com` → @rulosant
  - `sometimesocrazy@gmail.com` → @maycuatroi1
- No content, feature, or code logic changes were introduced—this is a documentation metadata improvement only. 🛠️

### 🎯 Purpose & Impact
- Improves contributor attribution by correctly linking authors to their GitHub identities. 👥
- Helps documentation pages display author avatars and usernames more completely and professionally. 🖼️
- Makes the handbook ecosystem more transparent and contributor-friendly, especially for readers exploring who wrote or maintains content. 📚
- Low-risk change with no effect on runtime behavior or user-facing product functionality. ✅