### PR TITLE
Remove private Rippling app links

### DIFF
--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -199,7 +199,7 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
 
         **Yes**, Rippling MDM is **mandatory** on all devices used for work before accessing company data.
 
-    Install from: [app.rippling.com/enroll-device](https://app.rippling.com/enroll-device)
+    Install from the device enrollment page in your Rippling account.
 
 ??? question "What if my equipment breaks or gets lost?"
 

--- a/docs/en/people/index.md
+++ b/docs/en/people/index.md
@@ -207,7 +207,7 @@ Also review our [Social Media Policy](../contributions/social-media-policy.md) f
 
 ### Key Resources
 
-- **[Rippling](https://app.rippling.com/)**: HR portal for PTO requests, profile updates, and equipment
+- **Rippling**: HR portal for PTO requests, profile updates, and equipment
 - **[Vanta](https://app.vanta.com/)**: Compliance training and security policies
 - **[Ultralytics Portal](https://portal.ultralytics.com/signin)**: Your gateway to onboarding, real-time dashboards, powerful AI agent controls, and essential ops tools.
 - **[FAQ](../faq/index.md)**: Common questions and answers

--- a/docs/en/people/onboarding.md
+++ b/docs/en/people/onboarding.md
@@ -318,7 +318,7 @@ Work with your manager to define specific, measurable goals:
 
 ### Tools & Access
 
-- **[Rippling](https://app.rippling.com/)**: HR, PTO, equipment, compliance training
+- **Rippling**: HR, PTO, equipment, compliance training
 - **[Google Workspace](https://workspace.google.com/)**: Email, calendar, drive, docs
 - **[Slack](https://ultralytics-work.slack.com/)**: Team communication and collaboration
 - **[GitHub](https://github.com/ultralytics/)**: Code repositories and issues

--- a/docs/en/security/team.md
+++ b/docs/en/security/team.md
@@ -120,7 +120,7 @@ Use the `#compliance` channel for:
 ### Security & Training Tools
 
 - **[Vanta](https://app.vanta.com/c/ultralytics/employee/onboarding)**: Delivers mandatory training programs and employee-applicable policies
-- **[Rippling](https://app.rippling.com/enroll-device)**: Manages and secures all company devices
+- **Rippling MDM**: Manages and secures all company devices
 
 ## Compliance Calendar & Audits
 

--- a/docs/en/tools/hardware.md
+++ b/docs/en/tools/hardware.md
@@ -229,7 +229,7 @@ graph LR
 
 **Installation Required:**
 
-- Install from **[app.rippling.com/enroll-device](https://app.rippling.com/enroll-device)**
+- Install from the device enrollment page in your Rippling account
 - Must be installed **before** accessing any company data
 - Failure to install blocks access to company resources
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR updates internal handbook docs to remove direct Rippling links and replace them with clearer, safer references to Rippling account pages and device enrollment instructions.

### 📊 Key Changes
- Replaced direct `app.rippling.com` and device enrollment links with plain-text references to **Rippling** in several handbook pages.
- Updated onboarding and people docs so **Rippling** is described as the HR, PTO, equipment, and compliance tool without linking directly to the app.
- Revised security and hardware documentation to refer to **Rippling MDM** more explicitly for device management.
- Changed installation guidance from a hardcoded enrollment URL to: “use the device enrollment page in your Rippling account.”
- Applied these edits across multiple sections, including:
  - FAQ
  - People / onboarding
  - Security team docs
  - Hardware setup docs

### 🎯 Purpose & Impact
- Improves clarity 🧭 by telling employees where to go inside their Rippling account instead of relying on fixed direct links.
- Reduces the risk of broken, outdated, or inaccessible links 🔗 as internal app URLs may change over time.
- Makes security and device setup instructions more consistent 🔒, especially around mandatory Rippling MDM enrollment.
- Creates a cleaner onboarding experience for team members 👋 by simplifying tool references across the handbook.
- Low-impact technical change ⚙️: no product features or code behavior changed, but documentation should now be easier to maintain and follow.