### PR TITLE
Bump MkDocs plugin requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "pytest-cov",
     "coverage[toml]",
     "zensical>=0.0.15",
-    "mkdocs-ultralytics-plugin>=0.2.4", # for meta descriptions and images, dates and authors
+    "mkdocs-ultralytics-plugin>=0.2.5", # for meta descriptions and images, dates and authors
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 zensical>=0.0.15
-mkdocs-ultralytics-plugin>=0.2.4
+mkdocs-ultralytics-plugin>=0.2.5


### PR DESCRIPTION
## Summary
- Require `mkdocs-ultralytics-plugin>=0.2.5` in `pyproject.toml` and `requirements.txt`.

## Tests
- `git diff --check -- pyproject.toml requirements.txt`
- Parsed `pyproject.toml` and verified the dependency is `mkdocs-ultralytics-plugin>=0.2.5`
- Verified `requirements.txt` contains `mkdocs-ultralytics-plugin>=0.2.5`
- `python -m pip index versions mkdocs-ultralytics-plugin`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⬆️ This PR updates the `mkdocs-ultralytics-plugin` dependency from `0.2.4` to `0.2.5` in the Ultralytics Handbook project to bring in the latest documentation plugin improvements.

### 📊 Key Changes
- Updated `mkdocs-ultralytics-plugin` from `>=0.2.4` to `>=0.2.5` in `pyproject.toml` 🔧
- Updated the same plugin version in `requirements.txt` to keep dependency definitions consistent 📦
- No application code or content changes were introduced; this is a dependency maintenance update 🛠️

### 🎯 Purpose & Impact
- Helps the handbook use the latest fixes or enhancements available in the MkDocs Ultralytics plugin 🚀
- Keeps dependency files aligned, reducing the chance of version mismatch issues ✅
- Likely improves documentation build reliability and metadata handling, since this plugin supports features like meta descriptions, images, dates, and authors 📝
- Low-risk update for users, with impact mainly on documentation generation rather than end-user functionality 🙂