### PR TITLE
Update handbook home hero image to team offsite photo

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,7 +5,7 @@ keywords: Ultralytics handbook, employee handbook, company guide, AI handbook, Y
 
 # Welcome to the Ultralytics Handbook 🚀
 
-[![Ultralytics Team](https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/69009d67bee1b2807736006e_0637_One_Republic_September_2025_METTY_%20copy.jpg)](https://www.ultralytics.com/blog/ultralytics-key-highlights-from-yolo-vision-2025)
+[![Ultralytics Team](https://cdn.ul.run/i/6021a1da5cf0971632f17e25379b8a9e.avif)](https://www.ultralytics.com/blog/ultralytics-morocco-offsite-team-highlights-2026)
 
 Welcome to the [Ultralytics](https://www.ultralytics.com/) Handbook - your comprehensive guide to our company's mission, vision, values, and operational practices. This handbook provides essential insights and resources for team members, collaborators, and our global community.
 


### PR DESCRIPTION
## Summary
- Replaces the Webflow-hosted YOLO Vision 2025 hero JPG on the handbook home page with the Morocco offsite team photo on cdn.ul.run (AVIF).
- The image now links to the Morocco offsite highlights blog post.

## OG image
- handbook.ultralytics.com auto-derives OG/Twitter images from the first page image, converting cdn.ul.run .avif to its .webp sibling — the .webp already exists on the CDN (verified 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Ultralytics Handbook homepage hero image to feature the Morocco offsite team photo and links it to the related 2026 team highlights blog post. 📸

### 📊 Key Changes
- Replaced the existing homepage hero image in `docs/en/index.md` with a new AVIF image hosted on the Ultralytics CDN.
- Updated the hero image link from the YOLO Vision 2025 highlights blog post to the Morocco offsite team highlights 2026 blog post.

### 🎯 Purpose & Impact
- Refreshes the Handbook landing page with more current team imagery. ✨
- Improves alignment between the homepage visual and the linked content.
- Provides visitors and team members with a more relevant, people-focused introduction to the Ultralytics Handbook.