### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install dependencies
         run: |
           uv pip install --system -r requirements.txt mkdocs mkdocs-material


### PR DESCRIPTION
## Summary
- replace all 1 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 1 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the CI workflow to use Ultralytics’ shared `setup-uv` action for dependency management. ⚙️

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in the GitHub Actions workflow.
- Kept the existing Python 3.13 environment and dependency installation process unchanged.

### 🎯 Purpose & Impact

- Centralizes `uv` setup through an Ultralytics-maintained action. 🔧
- Improves consistency with shared Ultralytics CI practices.
- May simplify future maintenance and updates across repositories. 🚀