### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - uses: ultralytics/actions/setup-uv@main

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -62,7 +62,7 @@ jobs:
           git push origin "${{ github.event.inputs.tag_name }}"
 
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Upgraded GitHub Actions’ Python setup action from v6 to v7 across CI and release workflows. ⚙️

### 📊 Key Changes

- Updated `actions/setup-python` from `v6` to `v7` in:
  - `.github/workflows/ci.yml`
  - `.github/workflows/tag.yml`
- Preserved existing Python versions:
  - Python 3.13 for CI
  - Latest Python 3.x for tagging and releases

### 🎯 Purpose & Impact

- Keeps the repository’s automation workflows aligned with the latest supported GitHub Action version. 🔄
- Improves the reliability and maintainability of CI and release processes.
- No expected changes to end-user functionality or documentation behavior. ✅