### PR TITLE
Revise PTO policy notice requirements

### DIFF
--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -297,10 +297,10 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
     2. Wait for manager approval
     3. Update team calendar and Slack status
 
-    !!! warning "Notice Guidelines"
+    !!! warning "Notice Requirements"
 
         - **1-4 vacation days**: 1 week
-        - **5+ vacation days**: Ideally at least 1 month
+        - **5+ vacation days**: At least 1 month
         - **Contractors**: 30-day waiting period
 
 ??? question "What's the relocation policy?"

--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -297,7 +297,7 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
     2. Wait for manager approval
     3. Update team calendar and Slack status
 
-    !!! warning "Notice Requirements"
+    !!! warning "Notice Guidelines"
 
         - **1-4 vacation days**: 1 week
         - **5+ vacation days**: Ideally at least 1 month

--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -297,11 +297,7 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
     2. Wait for manager approval
     3. Update team calendar and Slack status
 
-    !!! warning "Notice Requirements"
-
-        - **1-4 vacation days**: 1 week
-        - **5+ vacation days**: 30 calendar days
-        - **Contractors**: 30-day waiting period
+    See the [PTO Policy](../people/pto-policy.md) for mandatory notice periods and counting rules.
 
 ??? question "What's the relocation policy?"
 

--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -299,8 +299,8 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
 
     !!! warning "Notice Requirements"
 
-        - **Vacation**: 2 weeks minimum
-        - **Short breaks**: 1 week minimum
+        - **1-4 vacation days**: 1 week
+        - **5+ vacation days**: Ideally at least 1 month
         - **Contractors**: 30-day waiting period
 
 ??? question "What's the relocation policy?"

--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -300,7 +300,7 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
     !!! warning "Notice Requirements"
 
         - **1-4 vacation days**: 1 week
-        - **5+ vacation days**: At least 1 month
+        - **5+ vacation days**: 30 calendar days
         - **Contractors**: 30-day waiting period
 
 ??? question "What's the relocation policy?"

--- a/docs/en/people/index.md
+++ b/docs/en/people/index.md
@@ -72,7 +72,7 @@ See complete [PTO Policy](pto-policy.md) for details on requesting time off, rol
 
 ### Requesting Time Off
 
-Provide 1 week's notice for 1-4 days of vacation and ideally 1 month's notice for 5 days or more, following these steps:
+Provide 1 week's notice for 1-4 days of vacation and 1 month's notice for 5 days or more, following these steps:
 
 1. Submit request in [Rippling](https://www.rippling.com/)
 2. Wait for manager approval

--- a/docs/en/people/index.md
+++ b/docs/en/people/index.md
@@ -72,7 +72,7 @@ See complete [PTO Policy](pto-policy.md) for details on requesting time off, rol
 
 ### Requesting Time Off
 
-Provide minimum 2 weeks notice for vacation, following these steps:
+Provide 1 week's notice for 1-4 days of vacation and ideally 1 month's notice for 5 days or more, following these steps:
 
 1. Submit request in [Rippling](https://www.rippling.com/)
 2. Wait for manager approval

--- a/docs/en/people/index.md
+++ b/docs/en/people/index.md
@@ -72,7 +72,7 @@ See complete [PTO Policy](pto-policy.md) for details on requesting time off, rol
 
 ### Requesting Time Off
 
-Provide 1 week's notice for 1-4 days of vacation and 1 month's notice for 5 days or more, following these steps:
+Provide 1 week's notice for 1-4 days of vacation and 30 calendar days' notice for 5 days or more, following these steps:
 
 1. Submit request in [Rippling](https://www.rippling.com/)
 2. Wait for manager approval

--- a/docs/en/people/index.md
+++ b/docs/en/people/index.md
@@ -72,7 +72,7 @@ See complete [PTO Policy](pto-policy.md) for details on requesting time off, rol
 
 ### Requesting Time Off
 
-Provide 1 week's notice for 1-4 days of vacation and 30 calendar days' notice for 5 days or more, following these steps:
+Follow the mandatory notice requirements in the [PTO Policy](pto-policy.md), then:
 
 1. Submit request in [Rippling](https://www.rippling.com/)
 2. Wait for manager approval

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -112,7 +112,7 @@ Employees earn additional PTO days based on length of service:
 
     **For planned time off**
 
-    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **1 month in advance for longer leave** (5+ days)
+    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **ideally 1 month in advance for longer leave** (5+ days)
     - :material-account-group: Coordinate with your team for coverage
     - :material-calendar-check: Update calendar and Slack status
     - :material-timer: Vacation available after **30 days of employment**
@@ -121,7 +121,7 @@ Employees earn additional PTO days based on length of service:
 
     !!! warning "Longer Trips"
 
-        Provide **1 month notice** for vacations exceeding 5+ days
+        Provide **ideally 1 month notice** for vacations lasting **5 days or more**
 
 === "Sick Leave"
 
@@ -203,7 +203,7 @@ flowchart TD
 | Leave Type         | Notice Required          | Example                                             |
 | ------------------ | ------------------------ | --------------------------------------------------- |
 | **1-4 days**       | 1 week                   | Submit by Monday for a request the following Monday |
-| **5+ days**        | Ideally at least 1 month | Submit by early July for an Ausut 1-14 trip         |
+| **5+ days**        | Ideally at least 1 month | Submit by early July for an August 1-14 trip        |
 | **Sick leave**     | ASAP                     | Same-day notification                               |
 | **Birthday leave** | 1 week                   | Casual team notification                            |
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -207,15 +207,15 @@ flowchart TD
 | **Sick leave**     | ASAP             | Same-day notification                               |
 | **Birthday leave** | 1 week           | Submit in Rippling 1 week before                    |
 
-Vacation length is the total number of requested workdays in one continuous absence, including adjacent requests. One week means 7 calendar days, measured from the first day of leave.
+Vacation length is the total number of requested vacation workdays in one continuous absence, including adjacent requests. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
 
 !!! warning "Approval at manager's discretion"
 
     Vacation and birthday leave requests that do not meet the minimum notice requirements will be denied. Compliant requests remain subject to manager approval based on business continuity.
 
-!!! info "Take PTO only once approved"
+!!! info "Take planned leave only once approved"
 
-    Employees request time off in our HRIS (Rippling). The manager will respond within 3-5 business days and no later than the business day before leave begins. It is the employee's responsibility to follow up with the manager if the response is time sensitive. Paid time off can only be taken once it has been approved by the manager in our HRIS (Rippling).
+    Employees request time off in our HRIS (Rippling). For vacation and birthday leave, the manager will respond within 5 business days or by the business day before leave begins, whichever is earlier. It is the employee's responsibility to follow up with the manager if the response is time sensitive. Vacation and birthday leave can only be taken once approved by the manager in Rippling.
 
 ## Coordination and Coverage 🤝
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -200,16 +200,16 @@ flowchart TD
 
 ### Minimum Notice Requirements
 
-| Leave Type           | Notice Required | Example                          |
-| -------------------- | --------------- | -------------------------------- |
-| **1-4 days**         | 1 week          | Submit by Monday for a request the following Monday  |
-| **5+ days**     | Ideally at least 1 month          | Submit by early July for an Ausut 1-14 trip |
-| **Sick leave**       | ASAP            | Same-day notification            |
-| **Birthday leave**   | 1 week          | Casual team notification         |
+| Leave Type         | Notice Required          | Example                                             |
+| ------------------ | ------------------------ | --------------------------------------------------- |
+| **1-4 days**       | 1 week                   | Submit by Monday for a request the following Monday |
+| **5+ days**        | Ideally at least 1 month | Submit by early July for an Ausut 1-14 trip         |
+| **Sick leave**     | ASAP                     | Same-day notification                               |
+| **Birthday leave** | 1 week                   | Casual team notification                            |
 
 !!! warning "Approval at manager's discretion"
 
-    While we always try to accommodate where possible, we also need to balance business continuity. The more notice, the better.   
+    While we always try to accommodate where possible, we also need to balance business continuity. The more notice, the better.
 
 !!! info "Take PTO only once approved"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -198,7 +198,7 @@ flowchart TD
 2. **Manager approval** - Your direct manager approves in Rippling
 3. **Update team** - Notify colleagues and update calendar/Slack
 
-### Minimum Notice Requirements
+### Notice Guidelines
 
 | Leave Type         | Notice Required          | Example                                             |
 | ------------------ | ------------------------ | --------------------------------------------------- |

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -112,7 +112,7 @@ Employees earn additional PTO days based on length of service:
 
     **For planned time off**
 
-    - :material-calendar-clock: Submit requests **2 weeks in advance**
+    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **1 month in advance for longer leave** (5+ days)
     - :material-account-group: Coordinate with your team for coverage
     - :material-calendar-check: Update calendar and Slack status
     - :material-timer: Vacation available after **30 days of employment**
@@ -121,7 +121,7 @@ Employees earn additional PTO days based on length of service:
 
     !!! warning "Longer Trips"
 
-        Provide **1 month notice** for vacations exceeding 2 weeks
+        Provide **1 month notice** for vacations exceeding 5+ days
 
 === "Sick Leave"
 
@@ -202,14 +202,18 @@ flowchart TD
 
 | Leave Type           | Notice Required | Example                          |
 | -------------------- | --------------- | -------------------------------- |
-| **Planned vacation** | 2 weeks         | Submit by May 1 for May 15 trip  |
-| **Short breaks**     | 1 week          | Submit by Monday for next Monday |
+| **1-4 days**         | 1 week          | Submit by Monday for a request the following Monday  |
+| **5+ days**     | Ideally at least 1 month          | Submit by early July for an Ausut 1-14 trip |
 | **Sick leave**       | ASAP            | Same-day notification            |
 | **Birthday leave**   | 1 week          | Casual team notification         |
 
-!!! warning "Longer Vacations"
+!!! warning "Approval at manager's discretion"
 
-    **Provide 1 month notice** for vacations exceeding 2 weeks to ensure proper coverage planning.
+    While we always try to accommodate where possible, we also need to balance business continuity. The more notice, the better.   
+
+!!! info "Take PTO only once approved"
+
+    Employees request time off in our HRIS (Rippling). The manager will respond within 3-5 business days. It is the employee's responsibility to follow up with the manager if the response is time sensitive. Paid time off can only be taken once it has been approved by the manager in our HRIS (Rippling).
 
 ## Coordination and Coverage 🤝
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -207,7 +207,7 @@ flowchart TD
 | **Sick leave**     | ASAP             | Same-day notification                               |
 | **Birthday leave** | 1 week           | Submit in Rippling 1 week before                    |
 
-Vacation length is the total number of requested workdays in one continuous absence, including adjacent requests. Notice is measured from the first day of leave.
+Vacation length is the total number of requested workdays in one continuous absence, including adjacent requests. One week means 7 calendar days, measured from the first day of leave.
 
 !!! warning "Approval at manager's discretion"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -112,7 +112,7 @@ Employees earn additional PTO days based on length of service:
 
     **For planned time off**
 
-    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **30 calendar days in advance for longer leave** (5+ days)
+    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **at least 1 month in advance for longer leave** (5+ days)
     - :material-account-group: Coordinate with your team for coverage
     - :material-calendar-check: Update calendar and Slack status
     - :material-timer: Vacation available after **30 days of employment**
@@ -199,19 +199,19 @@ flowchart TD
 | Leave Type                        | Notice Required  | Example                                             |
 | --------------------------------- | ---------------- | --------------------------------------------------- |
 | **1-4 planned flexible PTO days** | 1 week           | Submit by Monday for a request the following Monday |
-| **5+ planned flexible PTO days**  | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
+| **5+ planned flexible PTO days**  | At least 1 month | Submit by early July for an August 1-14 trip        |
 | **Sick leave**                    | ASAP             | Same-day notification                               |
 | **Birthday leave**                | 1 week           | Submit in Rippling 1 week before                    |
 
-Planned flexible PTO length is the total requested workdays in one continuous absence. Requests are one absence when no scheduled workday falls between them. Modified or extended requests are reevaluated using the revised total and original first day of leave. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
+Count the total workdays in the planned flexible PTO request. Birthday leave is evaluated separately.
 
 !!! warning "Approval at manager's discretion"
 
-    Planned flexible PTO and birthday leave requests that do not meet the minimum notice requirements will be denied. Compliant requests remain subject to manager approval based on business continuity.
+    Requests must meet the minimum notice requirements. Managers review each request at their discretion, balancing employee needs with business continuity.
 
 !!! info "Take planned leave only once approved"
 
-    Employees request time off in our HRIS (Rippling). For planned flexible PTO and birthday leave, the manager will respond within 3 business days. If the deadline passes without a response, the employee must escalate to the HR team in `#hr`. HR may approve or deny the request within 2 business days or by the business day before leave begins, whichever is earlier. Planned flexible PTO and birthday leave can only be taken once approved in Rippling.
+    Employees request time off in our HRIS (Rippling). Managers will respond within 3-5 business days. If a response is time sensitive, follow up with your manager or the HR team in `#hr`. Planned flexible PTO and birthday leave can only be taken once approved in Rippling.
 
 ## Coordination and Coverage 🤝
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -119,10 +119,6 @@ Employees earn additional PTO days based on length of service:
     - :material-airplane: Maximum single vacation: **35 days**
     - :material-handshake: Up to **5 days negative balance** allowed with manager approval
 
-    !!! warning "Longer Trips"
-
-        Provide **30 calendar days' notice** for vacations lasting **5 days or more**
-
 === "Sick Leave"
 
     **When you're feeling unwell**
@@ -202,20 +198,20 @@ flowchart TD
 
 | Leave Type         | Notice Required  | Example                                             |
 | ------------------ | ---------------- | --------------------------------------------------- |
-| **1-4 days**       | 1 week           | Submit by Monday for a request the following Monday |
-| **5+ days**        | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
+| **1-4 planned leave days** | 1 week           | Submit by Monday for a request the following Monday |
+| **5+ planned leave days**  | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
 | **Sick leave**     | ASAP             | Same-day notification                               |
 | **Birthday leave** | 1 week           | Submit in Rippling 1 week before                    |
 
-Vacation length is the total number of requested vacation workdays in one continuous absence, including adjacent requests. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
+Planned flexible PTO length is the total number of requested workdays in one continuous absence, including adjacent requests. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
 
 !!! warning "Approval at manager's discretion"
 
-    Vacation and birthday leave requests that do not meet the minimum notice requirements will be denied. Compliant requests remain subject to manager approval based on business continuity.
+    Planned flexible PTO and birthday leave requests that do not meet the minimum notice requirements will be denied. Compliant requests remain subject to manager approval based on business continuity.
 
 !!! info "Take planned leave only once approved"
 
-    Employees request time off in our HRIS (Rippling). For vacation and birthday leave, the manager will respond within 5 business days or by the business day before leave begins, whichever is earlier. It is the employee's responsibility to follow up with the manager if the response is time sensitive. Vacation and birthday leave can only be taken once approved by the manager in Rippling.
+    Employees request time off in our HRIS (Rippling). For planned flexible PTO and birthday leave, the manager will respond within 5 business days or by the business day before leave begins, whichever is earlier. If the deadline passes without a response, the employee must escalate to the HR team in `#hr`. Planned flexible PTO and birthday leave can only be taken once approved by the manager in Rippling.
 
 ## Coordination and Coverage 🤝
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -148,8 +148,8 @@ Employees earn additional PTO days based on length of service:
     **Celebrate your special day!**
 
     - :material-cake: Schedule on or near your birthday
-    - :material-check-circle: No formal approval needed
-    - :material-account-voice: Just inform your team
+    - :material-check-circle: Manager approval required through Rippling
+    - :material-account-voice: Inform your team after approval
 
 ### Official Holiday Calendars
 
@@ -205,11 +205,13 @@ flowchart TD
 | **1-4 days**       | 1 week           | Submit by Monday for a request the following Monday |
 | **5+ days**        | At least 1 month | Submit by early July for an August 1-14 trip        |
 | **Sick leave**     | ASAP             | Same-day notification                               |
-| **Birthday leave** | 1 week           | Casual team notification                            |
+| **Birthday leave** | 1 week           | Submit in Rippling 1 week before                    |
+
+Vacation length is the number of requested workdays. Notice periods are calendar periods measured from the first day of leave.
 
 !!! warning "Approval at manager's discretion"
 
-    While we always try to accommodate where possible, we also need to balance business continuity. The more notice, the better.
+    Requests that meet the minimum notice requirements remain subject to manager approval based on business continuity.
 
 !!! info "Take PTO only once approved"
 
@@ -324,8 +326,8 @@ Exceptions may be considered for:
     **Scenario:** Birthday on Thursday, July 10
 
     ```
-    1. July 3: Mention to team: "Taking July 10 off for birthday"
-    2. July 8: Submit in Rippling for July 10
+    1. July 3: Submit in Rippling for July 10
+    2. After approval: Notify the team
     3. July 9: Set auto-responder, update status
     4. July 10: Enjoy your day! 🎂
     ```

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -200,12 +200,12 @@ flowchart TD
 
 ### Minimum Notice Requirements
 
-| Leave Type         | Notice Required          | Example                                             |
-| ------------------ | ------------------------ | --------------------------------------------------- |
-| **1-4 days**       | 1 week                   | Submit by Monday for a request the following Monday |
-| **5+ days**        | At least 1 month         | Submit by early July for an August 1-14 trip        |
-| **Sick leave**     | ASAP                     | Same-day notification                               |
-| **Birthday leave** | 1 week                   | Casual team notification                            |
+| Leave Type         | Notice Required  | Example                                             |
+| ------------------ | ---------------- | --------------------------------------------------- |
+| **1-4 days**       | 1 week           | Submit by Monday for a request the following Monday |
+| **5+ days**        | At least 1 month | Submit by early July for an August 1-14 trip        |
+| **Sick leave**     | ASAP             | Same-day notification                               |
+| **Birthday leave** | 1 week           | Casual team notification                            |
 
 !!! warning "Approval at manager's discretion"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -196,12 +196,12 @@ flowchart TD
 
 ### Minimum Notice Requirements
 
-| Leave Type         | Notice Required  | Example                                             |
-| ------------------ | ---------------- | --------------------------------------------------- |
+| Leave Type                 | Notice Required  | Example                                             |
+| -------------------------- | ---------------- | --------------------------------------------------- |
 | **1-4 planned leave days** | 1 week           | Submit by Monday for a request the following Monday |
 | **5+ planned leave days**  | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
-| **Sick leave**     | ASAP             | Same-day notification                               |
-| **Birthday leave** | 1 week           | Submit in Rippling 1 week before                    |
+| **Sick leave**             | ASAP             | Same-day notification                               |
+| **Birthday leave**         | 1 week           | Submit in Rippling 1 week before                    |
 
 Planned flexible PTO length is the total number of requested workdays in one continuous absence, including adjacent requests. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -112,7 +112,7 @@ Employees earn additional PTO days based on length of service:
 
     **For planned time off**
 
-    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **ideally 1 month in advance for longer leave** (5+ days)
+    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **1 month in advance for longer leave** (5+ days)
     - :material-account-group: Coordinate with your team for coverage
     - :material-calendar-check: Update calendar and Slack status
     - :material-timer: Vacation available after **30 days of employment**
@@ -121,7 +121,7 @@ Employees earn additional PTO days based on length of service:
 
     !!! warning "Longer Trips"
 
-        Provide **ideally 1 month notice** for vacations lasting **5 days or more**
+        Provide **1 month notice** for vacations lasting **5 days or more**
 
 === "Sick Leave"
 
@@ -198,12 +198,12 @@ flowchart TD
 2. **Manager approval** - Your direct manager approves in Rippling
 3. **Update team** - Notify colleagues and update calendar/Slack
 
-### Notice Guidelines
+### Minimum Notice Requirements
 
-| Leave Type         | Notice                   | Example                                             |
+| Leave Type         | Notice Required          | Example                                             |
 | ------------------ | ------------------------ | --------------------------------------------------- |
 | **1-4 days**       | 1 week                   | Submit by Monday for a request the following Monday |
-| **5+ days**        | Ideally at least 1 month | Submit by early July for an August 1-14 trip        |
+| **5+ days**        | At least 1 month         | Submit by early July for an August 1-14 trip        |
 | **Sick leave**     | ASAP                     | Same-day notification                               |
 | **Birthday leave** | 1 week                   | Casual team notification                            |
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -200,7 +200,7 @@ flowchart TD
 
 ### Notice Guidelines
 
-| Leave Type         | Notice Required          | Example                                             |
+| Leave Type         | Notice                   | Example                                             |
 | ------------------ | ------------------------ | --------------------------------------------------- |
 | **1-4 days**       | 1 week                   | Submit by Monday for a request the following Monday |
 | **5+ days**        | Ideally at least 1 month | Submit by early July for an August 1-14 trip        |

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -196,12 +196,12 @@ flowchart TD
 
 ### Minimum Notice Requirements
 
-| Leave Type                 | Notice Required  | Example                                             |
-| -------------------------- | ---------------- | --------------------------------------------------- |
+| Leave Type                        | Notice Required  | Example                                             |
+| --------------------------------- | ---------------- | --------------------------------------------------- |
 | **1-4 planned flexible PTO days** | 1 week           | Submit by Monday for a request the following Monday |
 | **5+ planned flexible PTO days**  | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
-| **Sick leave**             | ASAP             | Same-day notification                               |
-| **Birthday leave**         | 1 week           | Submit in Rippling 1 week before                    |
+| **Sick leave**                    | ASAP             | Same-day notification                               |
+| **Birthday leave**                | 1 week           | Submit in Rippling 1 week before                    |
 
 Planned flexible PTO length is the total requested workdays in one continuous absence. Requests are one absence when no scheduled workday falls between them. Modified or extended requests are reevaluated using the revised total and original first day of leave. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -211,7 +211,7 @@ Vacation length is the total number of requested workdays in one continuous abse
 
 !!! warning "Approval at manager's discretion"
 
-    Requests that meet the minimum notice requirements remain subject to manager approval based on business continuity.
+    Vacation and birthday leave requests that do not meet the minimum notice requirements will be denied. Compliant requests remain subject to manager approval based on business continuity.
 
 !!! info "Take PTO only once approved"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -112,7 +112,7 @@ Employees earn additional PTO days based on length of service:
 
     **For planned time off**
 
-    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **1 month in advance for longer leave** (5+ days)
+    - :material-calendar-clock: Submit requests **1 week in advance for shorter leave** (1-4 days), and **30 calendar days in advance for longer leave** (5+ days)
     - :material-account-group: Coordinate with your team for coverage
     - :material-calendar-check: Update calendar and Slack status
     - :material-timer: Vacation available after **30 days of employment**
@@ -121,7 +121,7 @@ Employees earn additional PTO days based on length of service:
 
     !!! warning "Longer Trips"
 
-        Provide **1 month notice** for vacations lasting **5 days or more**
+        Provide **30 calendar days' notice** for vacations lasting **5 days or more**
 
 === "Sick Leave"
 
@@ -203,11 +203,11 @@ flowchart TD
 | Leave Type         | Notice Required  | Example                                             |
 | ------------------ | ---------------- | --------------------------------------------------- |
 | **1-4 days**       | 1 week           | Submit by Monday for a request the following Monday |
-| **5+ days**        | At least 1 month | Submit by early July for an August 1-14 trip        |
+| **5+ days**        | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
 | **Sick leave**     | ASAP             | Same-day notification                               |
 | **Birthday leave** | 1 week           | Submit in Rippling 1 week before                    |
 
-Vacation length is the number of requested workdays. Notice periods are calendar periods measured from the first day of leave.
+Vacation length is the total number of requested workdays in one continuous absence, including adjacent requests. Notice is measured from the first day of leave.
 
 !!! warning "Approval at manager's discretion"
 
@@ -215,7 +215,7 @@ Vacation length is the number of requested workdays. Notice periods are calendar
 
 !!! info "Take PTO only once approved"
 
-    Employees request time off in our HRIS (Rippling). The manager will respond within 3-5 business days. It is the employee's responsibility to follow up with the manager if the response is time sensitive. Paid time off can only be taken once it has been approved by the manager in our HRIS (Rippling).
+    Employees request time off in our HRIS (Rippling). The manager will respond within 3-5 business days and no later than the business day before leave begins. It is the employee's responsibility to follow up with the manager if the response is time sensitive. Paid time off can only be taken once it has been approved by the manager in our HRIS (Rippling).
 
 ## Coordination and Coverage 🤝
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -198,12 +198,12 @@ flowchart TD
 
 | Leave Type                 | Notice Required  | Example                                             |
 | -------------------------- | ---------------- | --------------------------------------------------- |
-| **1-4 planned leave days** | 1 week           | Submit by Monday for a request the following Monday |
-| **5+ planned leave days**  | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
+| **1-4 planned flexible PTO days** | 1 week           | Submit by Monday for a request the following Monday |
+| **5+ planned flexible PTO days**  | 30 calendar days | Submit by July 2 for an August 1-14 trip            |
 | **Sick leave**             | ASAP             | Same-day notification                               |
 | **Birthday leave**         | 1 week           | Submit in Rippling 1 week before                    |
 
-Planned flexible PTO length is the total number of requested workdays in one continuous absence, including adjacent requests. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
+Planned flexible PTO length is the total requested workdays in one continuous absence. Requests are one absence when no scheduled workday falls between them. Modified or extended requests are reevaluated using the revised total and original first day of leave. Birthday leave is evaluated separately. One week means 7 calendar days, measured from the first day of leave.
 
 !!! warning "Approval at manager's discretion"
 
@@ -211,7 +211,7 @@ Planned flexible PTO length is the total number of requested workdays in one con
 
 !!! info "Take planned leave only once approved"
 
-    Employees request time off in our HRIS (Rippling). For planned flexible PTO and birthday leave, the manager will respond within 5 business days or by the business day before leave begins, whichever is earlier. If the deadline passes without a response, the employee must escalate to the HR team in `#hr`. Planned flexible PTO and birthday leave can only be taken once approved by the manager in Rippling.
+    Employees request time off in our HRIS (Rippling). For planned flexible PTO and birthday leave, the manager will respond within 3 business days. If the deadline passes without a response, the employee must escalate to the HR team in `#hr`. HR may approve or deny the request within 2 business days or by the business day before leave begins, whichever is earlier. Planned flexible PTO and birthday leave can only be taken once approved in Rippling.
 
 ## Coordination and Coverage 🤝
 


### PR DESCRIPTION
Updates PTO notice requirements to a length-based standard (1 week for 1-4 day requests, at least 1 month for 5+ days), clarifies that approval is at manager's discretion balancing accommodation against business continuity, and adds explicit response-time expectations (manager response within 3-5 business days and employee follow-up when time-sensitive, planned leave only after approval in Rippling). Also aligns the Vacation Leave tab and standard vacation example with the new notice periods.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📅 Updated PTO guidance to clarify notice periods, approval requirements, and coordination steps.

### 📊 Key Changes

- Replaced duplicated notice-period details in the FAQ and People pages with links to the central [PTO Policy](../people/pto-policy.md).
- Updated planned flexible PTO requirements:
  - **1–4 workdays:** Submit at least **1 week in advance**.
  - **5 or more workdays:** Submit at least **1 month in advance**.
- Clarified that notice is based on the total number of planned workdays, while birthday leave is evaluated separately.
- Added manager discretion language for reviewing requests and balancing business continuity.
- Clarified that planned flexible PTO and birthday leave require approval in Rippling before being taken.
- Updated birthday leave guidance to require manager approval before notifying the team.

### 🎯 Purpose & Impact

- 🧭 Establishes one authoritative source for PTO notice requirements, reducing conflicting documentation.
- ✅ Gives employees clearer expectations for requesting short and extended leave.
- 🤝 Improves planning, coverage coordination, and approval workflows for managers and teams.
- ⚠️ Helps prevent unapproved time off by emphasizing that requests must be approved in Rippling first.