### PR TITLE
Clean up pyproject.toml template leftovers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,11 @@ zensical build                                            # build static site in
 mkdocs build --strict                                     # the CI check (ci.yml): warnings are errors
 npm run build                                             # Vercel production build: docs/build_docs.js -> docs/build_docs.py
 ruff format . && ruff check --fix .                       # Python format/lint (line-length 120 from pyproject.toml)
-codespell                                                 # spelling (ignore-list in pyproject.toml [tool.codespell])
+codespell                                                 # spelling (Ultralytics Actions passes its own flags in CI)
 ```
 
 - CI (`ci.yml`) runs a single `build-docs` job on ubuntu-latest with Python 3.13 — no matrix; `pyproject.toml` declares `requires-python = ">=3.8"`.
-- There is no test suite and no coverage run in CI — `mkdocs build --strict` is the only build gate (the pytest/coverage dependencies in `pyproject.toml` are unused).
+- There is no test suite and no coverage run in CI — `mkdocs build --strict` is the only build gate.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,14 @@
 # Key Sections:
 # - [build-system]: Specifies the build requirements and backend (e.g., setuptools, wheel).
 # - [project]: Includes details like name, version, description, authors, dependencies and more.
-# - [project.optional-dependencies]: Provides additional, optional packages for extended features.
-# - [tool.*]: Configures settings for various tools (pytest, yapf, etc.) used in the project.
+# - [tool.*]: Configures settings for the tools used in the project (Ruff).
 
-# Installation:
-# The Handbook can be installed from the repository with: 'pip install git+https://github.com/ultralytics/handbook.git@main'
-# For development purposes, you can install the package in editable mode with: 'pip install -e .'
-# This approach allows for real-time code modifications without the need for re-installation.
+# Site build:
+# This repository is documentation only and ships no importable package. Install the build dependencies with
+# 'pip install -r requirements.txt', then run 'zensical serve' for local preview or 'zensical build' for a static build.
 
 # Documentation:
-# For comprehensive documentation and usage instructions, visit: https://docs.ultralytics.com
+# The published site lives at https://handbook.ultralytics.com
 
 [build-system]
 requires = ["setuptools>=82.0.1", "wheel"]
@@ -61,27 +59,16 @@ classifiers = [# Optional, for a list of valid classifiers, see https://pypi.org
 
 # Required dependencies ------------------------------------------------------------------------------------------------
 dependencies = [
-    "pytest",
-    "pytest-cov",
-    "coverage[toml]",
     "zensical>=0.0.15",
     "mkdocs-ultralytics-plugin>=0.2.5", # for meta descriptions and images, dates and authors
 ]
 
-# Optional dependencies ------------------------------------------------------------------------------------------------
-[project.optional-dependencies] # Optional
-tests = ["pytest"]
-
 [project.urls]  # Optional
 "Homepage" = "https://ultralytics.com"
 "Source" = "https://github.com/ultralytics/handbook"
-"Documentation" = "https://docs.ultralytics.com"
-"Handbook" = "https://handbook.ultralytics.com"
+"Documentation" = "https://handbook.ultralytics.com"
 "Bug Reports" = "https://github.com/ultralytics/handbook/issues"
 "Changelog" = "https://github.com/ultralytics/handbook/releases"
-
-# [project.scripts]  # Optional
-# handbook = "handbook:main"  # executes the function `main` from this package when "handbook" is called.
 
 # Tools settings -------------------------------------------------------------------------------------------------------
 [tool.setuptools]  # configuration specific to the `setuptools` build backend.
@@ -90,7 +77,3 @@ package-data = {}
 
 [tool.ruff]
 line-length = 120
-
-[tool.codespell]
-ignore-words-list = "crate,nd,strack,dota,ane,segway,fo,gool,winn,commend"
-skip = '*.csv,*venv*,docs/??/,docs/mkdocs_??.yml'


### PR DESCRIPTION
`pyproject.toml` carried configuration copied from other Ultralytics repos that does not apply here. Nothing that runs in CI or on Vercel reads any of it — `ci.yml` installs from `requirements.txt` and Ultralytics Actions passes its own codespell flags — so this is documentation accuracy plus dead-config removal.

- Removed `pytest`, `pytest-cov`, and `coverage[toml]` from `dependencies`, and the `[project.optional-dependencies] tests` table. The repo has one Python file (`docs/build_docs.py`) and no tests; nothing imports any of them. `zensical` and `mkdocs-ultralytics-plugin` are genuinely used and stay.
- Removed `[tool.codespell]`. Its `ignore-words-list` was YOLO vocabulary (`strack`, `dota`, `segway`, …) and its `skip` globs pointed at `*.csv` and `docs/mkdocs_??.yml`, neither of which exists here, while `docs/??/` matched `docs/en/` — the only content in the repo. Verified with codespell 2.4.1 that the repo is clean with no ignore list and no skips.
- Removed the commented-out `[project.scripts]` placeholder.
- Header comments claimed the Handbook is pip-installable (`packages = []`, so it is not) and pointed at docs.ultralytics.com. Replaced with the real build instructions and handbook.ultralytics.com.
- `[project.urls]`: `Documentation` pointed at docs.ultralytics.com, which does not host this repo's docs. Repointed to handbook.ultralytics.com and dropped the now-duplicate `Handbook` entry.
- Updated the two `AGENTS.md` lines that referenced the removed config.

Untouched: `name`, `version`, `requires-python`, classifiers, and `[tool.setuptools]`. Verified the file still parses with `tomllib`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Streamlines the Handbook project configuration to reflect its documentation-only workflow and simplify development tooling. 📚

### 📊 Key Changes

- Removed unused testing and coverage dependencies, including `pytest`, `pytest-cov`, and `coverage`.
- Updated `pyproject.toml` instructions to focus on building and previewing the site with `zensical`.
- Corrected project links so the main documentation URL points to the Handbook site.
- Removed obsolete package installation, console-script, optional test, and Codespell configuration.
- Updated `AGENTS.md` to clarify that CI only runs the strict documentation build and that Codespell settings come from Ultralytics Actions.

### 🎯 Purpose & Impact

- Reduces unnecessary dependencies and configuration for a documentation-only repository. 🧹
- Makes contributor instructions more accurate and easier to follow.
- Keeps local development and CI guidance aligned with the current Zensical-based site workflow.
- Delegates spelling configuration to centralized CI tooling, simplifying maintenance without changing the documentation build gate. ✅