### PR TITLE
Update pto-policy.md

### DIFF
--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -204,7 +204,7 @@ flowchart TD
 | **Birthday leave**                | 1 week           | Submit in Rippling 1 week before                    |
 
 Count the total workdays in the planned flexible PTO request. Birthday leave is evaluated separately.
-Plan related flexible PTO requests together. If they total 5 or more workdays within any 10-calendar-day period, submit all related requests at least 1 month before the first day off. A later request that raises the total to 5 or more days must meet the same deadline and does not change the status of previously approved leave.
+Related flexible PTO requests that total 5 or more workdays within any 10-calendar-day period must be submitted together at least 1 month before the first day off.
 
 !!! warning "Approval at manager's discretion"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -204,6 +204,7 @@ flowchart TD
 | **Birthday leave**                | 1 week           | Submit in Rippling 1 week before                    |
 
 Count the total workdays in the planned flexible PTO request. Birthday leave is evaluated separately.
+<br/> **Note:** Multiple PTO requests which total 5+ days off within any 10 day window count as longer leave and require at least 1 month advance notice.
 
 !!! warning "Approval at manager's discretion"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -204,7 +204,7 @@ flowchart TD
 | **Birthday leave**                | 1 week           | Submit in Rippling 1 week before                    |
 
 Count the total workdays in the planned flexible PTO request. Birthday leave is evaluated separately.
-Related flexible PTO requests that total 5 or more workdays within any 10-calendar-day period must be submitted together at least 1 month before the first day off.
+**Note:** Multiple PTO requests submitted together that total 5 or more workdays within any 10-day period count as longer leave and require at least 1 month's advance notice.
 
 !!! warning "Approval at manager's discretion"
 

--- a/docs/en/people/pto-policy.md
+++ b/docs/en/people/pto-policy.md
@@ -204,7 +204,7 @@ flowchart TD
 | **Birthday leave**                | 1 week           | Submit in Rippling 1 week before                    |
 
 Count the total workdays in the planned flexible PTO request. Birthday leave is evaluated separately.
-<br/> **Note:** Multiple PTO requests which total 5+ days off within any 10 day window count as longer leave and require at least 1 month advance notice.
+Plan related flexible PTO requests together. If they total 5 or more workdays within any 10-calendar-day period, submit all related requests at least 1 month before the first day off. A later request that raises the total to 5 or more days must meet the same deadline and does not change the status of previously approved leave.
 
 !!! warning "Approval at manager's discretion"
 


### PR DESCRIPTION
Added note to capture instances of consecutive PTO requests

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies the advance-notice requirement for multiple PTO requests that collectively constitute longer leave.

### 📊 Key Changes
- Adds a note to `docs/en/people/pto-policy.md` stating that multiple PTO requests totaling 5 or more days off within any 10-day window are treated as longer leave.
- Requires at least 1 month of advance notice for these combined requests.

### 🎯 Purpose & Impact
- Helps employees and managers consistently interpret flexible PTO notice requirements.
- Improves planning and sets clearer expectations for leave requests spanning multiple submissions.