### PR TITLE
Sync development team GitHub profiles

### DIFF
--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -204,7 +204,6 @@ Feel free to reach out to team members for guidance:
 | Alexis Schutzger        | [picsalex](https://github.com/picsalex)                               |
 | Altaïr Kabunda-Margalet | [altair-jpg](https://github.com/altair-jpg)                           |
 | Anastasiia Khrapal      | [nastijakh](https://github.com/nastijakh)                             |
-| Andrei Banica           | [banica-ultralytics](https://github.com/banica-ultralytics)           |
 | Anthony Evans           | [antevansultralytics](https://github.com/antevansultralytics)         |
 | Antonina Poludena       | [Antonina2111](https://github.com/Antonina2111)                       |
 | Craig Johnston          | [craigjohnston1](https://github.com/craigjohnston1)                   |
@@ -236,7 +235,6 @@ Feel free to reach out to team members for guidance:
 | Mohammed Yasin          | [Y-T-G](https://github.com/Y-T-G)                                     |
 | Muhammad Rizwan Munawar | [RizwanMunawar](https://github.com/RizwanMunawar)                     |
 | Murat Raimbekov         | [raimbekovm](https://github.com/raimbekovm)                           |
-| Mykola Boiko            | [mykolaxboiko](https://github.com/mykolaxboiko)                       |
 | Nicolai Nielsen         | [niconielsen32](https://github.com/niconielsen32)                     |
 | Nuvola Ladi             | [NLadi](https://github.com/NLadi)                                     |
 | Olivia Wang             | [ziyue-olivia](https://github.com/ziyue-olivia)                       |
@@ -248,7 +246,6 @@ Feel free to reach out to team members for guidance:
 | Shuai (Louis) Lyu       | [ShuaiLYU](https://github.com/ShuaiLYU)                               |
 | Thomas Chuang           | [chuang091](https://github.com/chuang091)                             |
 | Yogendra Singh          | [yogendrasinghx](https://github.com/yogendrasinghx)                   |
-| Tigran Hakobyan         | [t-hakobyan](https://github.com/t-hakobyan)                           |
 | Zinnia Pourdad          | [zinnialp](https://github.com/zinnialp)                               |
 | Zuzana Kontrikova       | [zkontri](https://github.com/zkontri)                                 |
 

--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -205,15 +205,18 @@ Feel free to reach out to team members for guidance:
 | Altaïr Kabunda-Margalet | [altair-jpg](https://github.com/altair-jpg)                           |
 | Anastasiia Khrapal      | [nastijakh](https://github.com/nastijakh)                             |
 | Andrei Banica           | [banica-ultralytics](https://github.com/banica-ultralytics)           |
+| Anthony Evans           | [antevansultralytics](https://github.com/antevansultralytics)         |
 | Antonina Poludena       | [Antonina2111](https://github.com/Antonina2111)                       |
 | Craig Johnston          | [craigjohnston1](https://github.com/craigjohnston1)                   |
 | Darin Kabashi           | [darin-k](https://github.com/darin-k))                                |
+| Ed Crook                | [ed-yolo](https://github.com/ed-yolo)                                 |
 | Esat Kalfaoglu          | [artest08](https://github.com/artest08)                               |
 | Fatih Akyon             | [fcakyon](https://github.com/fcakyon)                                 |
 | Francesco Mattioli      | [ambitious-octopus](https://github.com/ambitious-octopus)             |
 | Giovanni Dal Zillio     | [ggg-dz-ultralytics](https://github.com/ggg-dz-ultralytics)           |
 | Glenn Jocher            | [glenn-jocher](https://github.com/glenn-jocher)                       |
 | Hannah Streif           | [HannahStreif](https://github.com/HannahStreif)                       |
+| Irene Calatrava         | [icalatrava](https://github.com/icalatrava)                           |
 | Jake Qian               | [fengqianjake](https://github.com/fengqianjake)                       |
 | Javier Chulvi           | [JaviChulvi](https://github.com/JaviChulvi)                           |
 | Jianing Qi （Jalyn）    | [jianing-Jalyn](https://github.com/jianing-Jalyn)                     |
@@ -227,10 +230,12 @@ Feel free to reach out to team members for guidance:
 | Leo Samsinger           | [lsamsinger](https://github.com/lsamsinger)                           |
 | Marius Keiser           | [Skillnoob](https://github.com/Skillnoob)                             |
 | Matt Bristow            | [matt-ultralytics](https://github.com/matt-ultralytics)               |
+| Maxim Sokolov           | [somal](https://github.com/somal)                                     |
 | Mengyu (Mason) Liu      | [lmycross](https://github.com/lmycross)                               |
 | Miles Deans             | [miles-deans-ultralytics](https://github.com/miles-deans-ultralytics) |
 | Mohammed Yasin          | [Y-T-G](https://github.com/Y-T-G)                                     |
 | Muhammad Rizwan Munawar | [RizwanMunawar](https://github.com/RizwanMunawar)                     |
+| Murat Raimbekov         | [raimbekovm](https://github.com/raimbekovm)                           |
 | Mykola Boiko            | [mykolaxboiko](https://github.com/mykolaxboiko)                       |
 | Nicolai Nielsen         | [niconielsen32](https://github.com/niconielsen32)                     |
 | Nuvola Ladi             | [NLadi](https://github.com/NLadi)                                     |


### PR DESCRIPTION
## Summary
- add missing current team GitHub profiles
- add the newly discovered `ed-yolo` org member
- remove Andrei Banica, Mykola Boiko, and Tigran Hakobyan

## Validation
- `zensical build --strict`
- authenticated Ultralytics org membership reconciliation

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the contributor guide’s team GitHub profile table to reflect current members and newly identified accounts.

### 📊 Key Changes

- Added GitHub profiles for Anthony Evans, Ed Crook (`ed-yolo`), Irene Calatrava, Maxim Sokolov, and Murat Raimbekov.
- Removed entries for Andrei Banica, Mykola Boiko, and Tigran Hakobyan.
- Updated the documented team contacts in `docs/en/contributions/how-to-contribute.md`.

### 🎯 Purpose & Impact

- Contributors now see a more current list of team members and GitHub profiles when seeking guidance.
- No application or runtime behavior changed; the update is limited to documentation.