### PR TITLE
Add missing team GitHub profiles to contribution guide

### DIFF
--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -214,6 +214,7 @@ Feel free to reach out to team members for guidance:
 | Giovanni Dal Zillio     | [ggg-dz-ultralytics](https://github.com/ggg-dz-ultralytics)           |
 | Glenn Jocher            | [glenn-jocher](https://github.com/glenn-jocher)                       |
 | Hannah Streif           | [HannahStreif](https://github.com/HannahStreif)                       |
+| Irene Calatrava         | [IreneCG](https://github.com/IreneCG)                                 |
 | Jake Qian               | [fengqianjake](https://github.com/fengqianjake)                       |
 | Javier Chulvi           | [JaviChulvi](https://github.com/JaviChulvi)                           |
 | Jianing Qi （Jalyn）    | [jianing-Jalyn](https://github.com/jianing-Jalyn)                     |
@@ -227,10 +228,12 @@ Feel free to reach out to team members for guidance:
 | Leo Samsinger           | [lsamsinger](https://github.com/lsamsinger)                           |
 | Marius Keiser           | [Skillnoob](https://github.com/Skillnoob)                             |
 | Matt Bristow            | [matt-ultralytics](https://github.com/matt-ultralytics)               |
+| Max Sokolov             | [somal](https://github.com/somal)                                     |
 | Mengyu (Mason) Liu      | [lmycross](https://github.com/lmycross)                               |
 | Miles Deans             | [miles-deans-ultralytics](https://github.com/miles-deans-ultralytics) |
 | Mohammed Yasin          | [Y-T-G](https://github.com/Y-T-G)                                     |
 | Muhammad Rizwan Munawar | [RizwanMunawar](https://github.com/RizwanMunawar)                     |
+| Murat Raimbekov         | [raimbekovm](https://github.com/raimbekovm)                           |
 | Mykola Boiko            | [mykolaxboiko](https://github.com/mykolaxboiko)                       |
 | Nicolai Nielsen         | [niconielsen32](https://github.com/niconielsen32)                     |
 | Nuvola Ladi             | [NLadi](https://github.com/NLadi)                                     |


### PR DESCRIPTION
### What changed
Added Irene Calatrava (IreneCG), Max Sokolov (somal), and Murat Raimbekov (raimbekovm) to the alphabetized development-team table with correct GitHub links; unverified: live URL resolution and `zensical build --strict` (no network/test suite in sandbox).

### Why
Update `docs/en/contributions/how-to-contribute.md`, owned by the handbook contribution-guide page, to add the three missing current team members to the alphabetized `Our Development Team` Markdown table with their GitHub profiles: Irene Calatrava → `IreneCG` (`https://github.com/IreneCG`), Max Sokolov → `somal` (`https://github.com/somal`), and Murat Raimbekov → `raimbekovm` (`https://github.com/raimbekovm`). Preserve the existing table formatting and all unrelated page content. Acceptance boundary: the rendered development-team table contains all three names linked to those exact GitHub profiles, in alphabetical order.

Requested by murat@ultralytics.com (job `cee849af3f4b`).