### PR TITLE
Fix Darin GitHub profile link

### DIFF
--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -207,7 +207,7 @@ Feel free to reach out to team members for guidance:
 | Anthony Evans           | [antevansultralytics](https://github.com/antevansultralytics)         |
 | Antonina Poludena       | [Antonina2111](https://github.com/Antonina2111)                       |
 | Craig Johnston          | [craigjohnston1](https://github.com/craigjohnston1)                   |
-| Darin Kabashi           | [darin-k](https://github.com/darin-k))                                |
+| Darin Kabashi           | [darin-k](https://github.com/darin-k)                                 |
 | Ed Crook                | [ed-yolo](https://github.com/ed-yolo)                                 |
 | Esat Kalfaoglu          | [artest08](https://github.com/artest08)                               |
 | Fatih Akyon             | [fcakyon](https://github.com/fcakyon)                                 |


### PR DESCRIPTION
## Summary

- remove the extra closing parenthesis from Darin Kabashi's GitHub profile URL

## Validation

- `zensical build --strict`
- `codespell docs/en/contributions/how-to-contribute.md`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Fixed the malformed GitHub profile link for Darin Kabashi in the contributor contact table.

### 📊 Key Changes

- Removed the extra closing parenthesis from the `darin-k` GitHub URL in `docs/en/contributions/how-to-contribute.md`.
- Corrected the Markdown table formatting for Darin Kabashi’s profile entry.

### 🎯 Purpose & Impact

- Darin Kabashi’s profile link now renders correctly in the contribution guide.
- No other documentation behavior or functionality changed.