### PR TITLE
Remove trailing slashes from Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the Ultralytics Handbook [site](https://handbook.ultralytics.com/) and [issues](https://github.com/ultralytics/handbook/issues) to see if a similar bug report already exists.
+        Please search the Ultralytics Handbook [site](https://handbook.ultralytics.com) and [issues](https://github.com/ultralytics/handbook/issues) to see if a similar bug report already exists.
       options:
         - label: >
             I have searched https://github.com/ultralytics/handbook/issues and did not find a similar report.
@@ -51,7 +51,7 @@ body:
       description: Share the page and browser information relevant to your report.
       placeholder: |
         Please include:
-        - Page URL (e.g., https://handbook.ultralytics.com/people/onboarding/)
+        - Page URL (e.g., https://handbook.ultralytics.com/people/onboarding)
         - Browser and version (e.g., Chrome 125, Safari 17)
         - OS (e.g., Ubuntu 20.04, macOS 13.5, Windows 11)
         - Any other environment details

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,10 +3,10 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📄 Handbook
-    url: https://handbook.ultralytics.com/
+    url: https://handbook.ultralytics.com
     about: Published Ultralytics Handbook and governance docs
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask the Ultralytics community for workflow help
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the Ultralytics Handbook [site](https://handbook.ultralytics.com/) and [issues](https://github.com/ultralytics/handbook/issues) to see if a similar feature request already exists.
+        Please search the Ultralytics Handbook [site](https://handbook.ultralytics.com) and [issues](https://github.com/ultralytics/handbook/issues) to see if a similar feature request already exists.
       options:
         - label: >
             I have searched https://github.com/ultralytics/handbook/issues and did not find a similar request.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the Ultralytics Handbook [site](https://handbook.ultralytics.com/), [issues](https://github.com/ultralytics/handbook/issues), and [Ultralytics discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
+        Please search the Ultralytics Handbook [site](https://handbook.ultralytics.com), [issues](https://github.com/ultralytics/handbook/issues), and [Ultralytics discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
       options:
         - label: >
             I checked the docs, issues, and discussions and could not find an answer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to AI coding agents (Claude Code, etc.) when working with code in this repository. CLAUDE.md is a symlink to this file.
 
-This repository (AGPL-3.0) is the Markdown source for the Ultralytics company handbook published at https://handbook.ultralytics.com/, covering our mission, values, onboarding, people, policies, security, and operations. It is documentation only — there is no application code.
+This repository (AGPL-3.0) is the Markdown source for the Ultralytics company handbook published at https://handbook.ultralytics.com, covering our mission, values, onboarding, people, policies, security, and operations. It is documentation only — there is no application code.
 
 ## Core Principles (CRITICAL)
 
@@ -42,7 +42,7 @@ codespell                          # spelling (Ultralytics Actions passes its ow
 
 ## Architecture
 
-This is a docs-only repository: the source for [handbook.ultralytics.com](https://handbook.ultralytics.com/), with all content as Markdown under `docs/en/` and no application code. The root `mkdocs.yml` is the transitional Zensical-compatible manifest consumed by local validation and the centralized publisher: `docs_dir: docs/en/`, `site_dir: site/`, plus navigation and metadata.
+This is a docs-only repository: the source for [handbook.ultralytics.com](https://handbook.ultralytics.com), with all content as Markdown under `docs/en/` and no application code. The root `mkdocs.yml` is the transitional Zensical-compatible manifest consumed by local validation and the centralized publisher: `docs_dir: docs/en/`, `site_dir: site/`, plus navigation and metadata.
 
 Production rendering does not run in this repository. The centralized publisher reads `mkdocs.yml` and `docs/en/` from `main`; Zensical provides a minimal local preview and strict content-validation path without production-owned site chrome.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 📚 Ultralytics Handbook
 
-Welcome to the **Ultralytics Handbook repository**! This repository houses the source files for the official [Ultralytics Handbook](https://handbook.ultralytics.com/) - your comprehensive guide to our **mission, vision, values, and operational practices**. [Zensical](https://zensical.org/) validates and previews the content locally; Ultralytics' centralized publishing service renders and deploys the production site.
+Welcome to the **Ultralytics Handbook repository**! This repository houses the source files for the official [Ultralytics Handbook](https://handbook.ultralytics.com) - your comprehensive guide to our **mission, vision, values, and operational practices**. [Zensical](https://zensical.org/) validates and previews the content locally; Ultralytics' centralized publishing service renders and deploys the production site.
 
 [![Check Broken links](https://github.com/ultralytics/handbook/actions/workflows/links.yml/badge.svg)](https://github.com/ultralytics/handbook/actions/workflows/links.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/handbook/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/handbook/actions/workflows/format.yml)
 [![jsDelivr hits](https://data.jsdelivr.com/v1/package/gh/ultralytics/llm/badge?style=rounded)](https://www.jsdelivr.com/package/gh/ultralytics/llm)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
 This Handbook serves as a **living document**, evolving alongside Ultralytics' growth. It aims to align team members, contributors, and the wider community with the core principles guiding our work in [artificial intelligence (AI)](https://www.ultralytics.com/glossary/artificial-intelligence-ai) and [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv). Whether you're new to Ultralytics or a seasoned team member, this resource provides insights into everything from our company philosophy to detailed workflows and operational processes, including our approach to [machine learning operations (MLOps)](https://www.ultralytics.com/glossary/machine-learning-operations-mlops).
@@ -104,7 +104,7 @@ Ultralytics offers two licensing options:
 
 ## ✉️ Contact
 
-For bug reports and feature requests related to the Ultralytics Handbook, please visit [GitHub Issues](https://github.com/ultralytics/handbook/issues). For questions, discussions, and community support, join our active communities on [Discord](https://discord.com/invite/ultralytics), [Reddit](https://www.reddit.com/r/ultralytics/), and the [Ultralytics Community Forums](https://community.ultralytics.com/). We're here to help with all things Ultralytics!
+For bug reports and feature requests related to the Ultralytics Handbook, please visit [GitHub Issues](https://github.com/ultralytics/handbook/issues). For questions, discussions, and community support, join our active communities on [Discord](https://discord.com/invite/ultralytics), [Reddit](https://www.reddit.com/r/ultralytics/), and the [Ultralytics Community Forums](https://community.ultralytics.com). We're here to help with all things Ultralytics!
 
 <br>
 <div align="center">

--- a/docs/en/contributions/community-engagement.md
+++ b/docs/en/contributions/community-engagement.md
@@ -85,7 +85,7 @@ Showcase projects built with [YOLO](https://docs.ultralytics.com/models):
 
 Help improve YOLO by reporting bugs with:
 
-- Clear [Minimum Reproducible Examples](https://docs.ultralytics.com/help/minimum-reproducible-example/)
+- Clear [Minimum Reproducible Examples](https://docs.ultralytics.com/help/minimum-reproducible-example)
 - Detailed environment information
 - Expected vs actual behavior
 - Error messages and logs
@@ -98,13 +98,13 @@ See [How to Contribute](how-to-contribute.md) for guidelines on submitting code 
 
 ### YOLO Vision Conference
 
-Annual conference bringing together the YOLO community for talks, workshops, and networking. Check [ultralytics.com](https://www.ultralytics.com/) for announcements.
+Annual conference bringing together the YOLO community for talks, workshops, and networking. Check [ultralytics.com](https://www.ultralytics.com) for announcements.
 
 ### Online Workshops
 
 Regular online workshops covering:
 
-- [YOLO fundamentals](https://docs.ultralytics.com/)
+- [YOLO fundamentals](https://docs.ultralytics.com)
 - Advanced [training techniques](https://docs.ultralytics.com/modes/train)
 - [Deployment strategies](https://docs.ultralytics.com/guides/model-deployment-options)
 - [Real-world applications](https://docs.ultralytics.com/guides)
@@ -126,7 +126,7 @@ We recognize outstanding community members through:
 
 ### Support Resources
 
-- [Documentation](https://docs.ultralytics.com/)
+- [Documentation](https://docs.ultralytics.com)
 - [GitHub Discussions](https://github.com/orgs/ultralytics/discussions)
 - [Discord Community](https://discord.com/invite/ultralytics)
 - [Development Team](how-to-contribute.md#our-development-team)

--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, contributing, open source, pull requests, code of conduct
 
 # How to Contribute 🚀
 
-Welcome! We're thrilled you're considering contributing to [Ultralytics](https://www.ultralytics.com/) open-source projects. Your involvement helps enhance the quality of our repositories and benefits the entire computer vision community.
+Welcome! We're thrilled you're considering contributing to [Ultralytics](https://www.ultralytics.com) open-source projects. Your involvement helps enhance the quality of our repositories and benefits the entire computer vision community.
 
 !!! tip "Complete Guidelines"
 
@@ -67,7 +67,7 @@ When contributing code:
 - **Consider compatibility**: Avoid breaking existing code
 - **Use consistent formatting**: Follow [Ruff Formatter](https://github.com/astral-sh/ruff)
 - **Add tests**: Include tests for new features
-- **Update docs**: Keep [documentation](https://docs.ultralytics.com/) current
+- **Update docs**: Keep [documentation](https://docs.ultralytics.com) current
 
 ### Coding Standards 📐
 
@@ -91,7 +91,7 @@ See [Development Workflow](../workflows/development.md) for complete coding stan
 
 ### Documentation 📚
 
-- Improve existing [documentation](https://docs.ultralytics.com/)
+- Improve existing [documentation](https://docs.ultralytics.com)
 - Add [tutorials and guides](https://docs.ultralytics.com/guides) for specific use cases
 - Fix typos and errors
 - Translate documentation to other languages
@@ -117,7 +117,7 @@ Help us improve by reporting bugs via [GitHub Issues](https://github.com/ultraly
 ### Bug Report Requirements
 
 1. **Check existing issues** to avoid duplicates
-2. **Create [Minimum Reproducible Example (MRE)](https://docs.ultralytics.com/help/minimum-reproducible-example/)** - Small, self-contained code that reproduces the issue
+2. **Create [Minimum Reproducible Example (MRE)](https://docs.ultralytics.com/help/minimum-reproducible-example)** - Small, self-contained code that reproduces the issue
 3. **Describe environment**: OS, Python version, library versions, hardware (CPU/GPU)
 4. **Explain expected vs actual behavior** with error messages and tracebacks
 
@@ -132,7 +132,7 @@ A Minimum Reproducible Example should:
 - **Format properly**: Use code blocks with triple backticks
 - **Be testable**: Others can run it without modifications
 
-See the complete [MRE Guide](https://docs.ultralytics.com/help/minimum-reproducible-example/) for detailed instructions.
+See the complete [MRE Guide](https://docs.ultralytics.com/help/minimum-reproducible-example) for detailed instructions.
 
 ## Reviewing Pull Requests 👀
 
@@ -256,7 +256,7 @@ Questions or need help?
 - Open an issue on [GitHub](https://github.com/ultralytics/ultralytics/issues)
 - Join [GitHub Discussions](https://github.com/orgs/ultralytics/discussions)
 - Connect on [Discord](https://discord.com/invite/ultralytics)
-- Check [documentation](https://docs.ultralytics.com/)
+- Check [documentation](https://docs.ultralytics.com)
 - Visit [Help Center](https://docs.ultralytics.com/help)
 - Browse [Ultralytics Blog](https://www.ultralytics.com/blog) for tutorials and guides
 - Explore [Solutions](https://www.ultralytics.com/solutions) for industry-specific applications
@@ -275,7 +275,7 @@ We're excited to see your ideas come to life and appreciate your commitment to a
 - [Documentation Workflow](../workflows/documentation.md) - Writing docs
 - [Code of Conduct](https://docs.ultralytics.com/help/code-of-conduct) - Community standards
 - [CLA Document](https://docs.ultralytics.com/help/CLA) - Contributor License Agreement
-- [MRE Guide](https://docs.ultralytics.com/help/minimum-reproducible-example/) - Bug reporting best practices
+- [MRE Guide](https://docs.ultralytics.com/help/minimum-reproducible-example) - Bug reporting best practices
 - [Ultralytics Blog](https://www.ultralytics.com/blog) - Tutorials and case studies
 - [Community Events](https://www.ultralytics.com/events) - Webinars and conferences
 - [Customer Stories](https://www.ultralytics.com/customers) - Real-world applications

--- a/docs/en/contributions/social-media-policy.md
+++ b/docs/en/contributions/social-media-policy.md
@@ -39,7 +39,7 @@ This policy applies to any platform where you can share or comment publicly, inc
 
 We encourage you to celebrate Ultralytics' work and community impact. You may share:
 
-- Official Ultralytics blogs, documentation, or updates **after** they've been published on our [website](https://www.ultralytics.com/) and/or social media channels
+- Official Ultralytics blogs, documentation, or updates **after** they've been published on our [website](https://www.ultralytics.com) and/or social media channels
 - Public press coverage or media mentions
 - Partner announcements or collaborations **after** Ultralytics has shared them
 - Open-source highlights, YOLO model releases, and event recaps already visible online

--- a/docs/en/faq/index.md
+++ b/docs/en/faq/index.md
@@ -433,7 +433,7 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
 
     <div class="grid cards" markdown>
 
-    -   :material-book: **[YOLO Documentation](https://docs.ultralytics.com/)**
+    -   :material-book: **[YOLO Documentation](https://docs.ultralytics.com)**
 
         ---
 
@@ -478,4 +478,4 @@ keywords: Ultralytics FAQ, employee questions, company policies, expense reimbur
     1. **Browse the handbook**: Use search or navigation to find specific topics
     2. **Ask your manager**: First point of contact for most questions
     3. **Contact specialized teams**: IT, Finance, Legal, Security
-    4. **Check documentation**: [YOLO Docs](https://docs.ultralytics.com/) for technical questions
+    4. **Check documentation**: [YOLO Docs](https://docs.ultralytics.com) for technical questions

--- a/docs/en/finance/index.md
+++ b/docs/en/finance/index.md
@@ -5,7 +5,7 @@ keywords: Ultralytics finance, finance handbook, expense reporting, reimbursemen
 
 # Ultralytics Finance Handbook 📘
 
-Welcome to the [Ultralytics](https://www.ultralytics.com/) Finance Handbook. This resource provides clear guidelines for employees regarding financial processes, reimbursements, budgeting, and expense management.
+Welcome to the [Ultralytics](https://www.ultralytics.com) Finance Handbook. This resource provides clear guidelines for employees regarding financial processes, reimbursements, budgeting, and expense management.
 
 ## Finance Overview 💡
 

--- a/docs/en/finance/referral-bonus.md
+++ b/docs/en/finance/referral-bonus.md
@@ -7,7 +7,7 @@ keywords: Ultralytics, Employee Referral, Referral Bonus, Hiring, Recruitment, T
 
 ## Overview 📌
 
-[Ultralytics](https://www.ultralytics.com/) offers a $5,000 bonus to employees who refer qualified candidates that join our team. This program helps us grow with talented individuals from employee networks.
+[Ultralytics](https://www.ultralytics.com) offers a $5,000 bonus to employees who refer qualified candidates that join our team. This program helps us grow with talented individuals from employee networks.
 
 !!! success "Referral Bonus"
 

--- a/docs/en/finance/travel.md
+++ b/docs/en/finance/travel.md
@@ -7,7 +7,7 @@ keywords: Ultralytics, Employee Travel Policy, per diem rates, travel responsibi
 
 ## Scope 📌
 
-This policy applies to all employees of [Ultralytics](https://www.ultralytics.com/) who are required to travel for business purposes. Employees are responsible for making their own travel arrangements while adhering to the guidelines outlined in this policy.
+This policy applies to all employees of [Ultralytics](https://www.ultralytics.com) who are required to travel for business purposes. Employees are responsible for making their own travel arrangements while adhering to the guidelines outlined in this policy.
 
 ## Employee Responsibilities 📋
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -7,7 +7,7 @@ keywords: Ultralytics handbook, employee handbook, company guide, AI handbook, Y
 
 [![Ultralytics Team](https://cdn.ul.run/i/6021a1da5cf0971632f17e25379b8a9e.avif)](https://www.ultralytics.com/blog/ultralytics-morocco-offsite-team-highlights-2026)
 
-Welcome to the [Ultralytics](https://www.ultralytics.com/) Handbook - your comprehensive guide to our company's mission, vision, values, and operational practices. This handbook provides essential insights and resources for team members, collaborators, and our global community.
+Welcome to the [Ultralytics](https://www.ultralytics.com) Handbook - your comprehensive guide to our company's mission, vision, values, and operational practices. This handbook provides essential insights and resources for team members, collaborators, and our global community.
 
 !!! info "Living Document"
 
@@ -195,7 +195,7 @@ Welcome to the [Ultralytics](https://www.ultralytics.com/) Handbook - your compr
 
     Quarterly objectives framework
 
-- :material-map: **[Product Roadmap](https://docs.ultralytics.com/)**
+- :material-map: **[Product Roadmap](https://docs.ultralytics.com)**
 
     ***
 
@@ -271,19 +271,19 @@ Welcome to the [Ultralytics](https://www.ultralytics.com/) Handbook - your compr
 
 <div class="grid cards" markdown>
 
-- :material-shield-star: **[Trust Center](https://trust.ultralytics.com/)**
+- :material-shield-star: **[Trust Center](https://trust.ultralytics.com)**
 
     ***
 
     Security documentation and certifications
 
-- :material-web: **[Ultralytics Website](https://www.ultralytics.com/)**
+- :material-web: **[Ultralytics Website](https://www.ultralytics.com)**
 
     ***
 
     Company information
 
-- :material-book: **[YOLO Documentation](https://docs.ultralytics.com/)**
+- :material-book: **[YOLO Documentation](https://docs.ultralytics.com)**
 
     ***
 

--- a/docs/en/people/onboarding.md
+++ b/docs/en/people/onboarding.md
@@ -206,7 +206,7 @@ Welcome to Ultralytics! This guide will help you navigate your first 90 days and
 
 **Technical**:
 
-- [YOLO Documentation](https://docs.ultralytics.com/) - Complete technical guide
+- [YOLO Documentation](https://docs.ultralytics.com) - Complete technical guide
 - [Development Workflow](../workflows/development.md) - PR process and standards
 - [CI/Testing](../workflows/ci-testing.md) - Quality and testing practices
 - Internal tech talks (recordings in shared drive)

--- a/docs/en/security/isms.md
+++ b/docs/en/security/isms.md
@@ -117,7 +117,7 @@ Our GRC platform (**[Vanta](https://app.vanta.com/)**) provides real-time compli
 
 !!! success "Public Commitment"
 
-    - **[Trust Center](https://trust.ultralytics.com/)**: Key security policies and procedures publicly available
+    - **[Trust Center](https://trust.ultralytics.com)**: Key security policies and procedures publicly available
     - **Compliance Attestations**: Certifications and audit reports published post-Q1 2026 audits
     - **Customer Security Reviews**: Detailed security information provided for customer due diligence
 
@@ -128,5 +128,5 @@ Our GRC platform (**[Vanta](https://app.vanta.com/)**) provides real-time compli
     | Channel | Details |
     | ------- | ------- |
     | **Email** | [security@ultralytics.com](mailto:security@ultralytics.com) |
-    | **Trust Center** | [trust.ultralytics.com](https://trust.ultralytics.com/) |
-    | **Open-Source Security Policy** | [docs.ultralytics.com/help/security/](https://docs.ultralytics.com/help/security) |
+    | **Trust Center** | [trust.ultralytics.com](https://trust.ultralytics.com) |
+    | **Open-Source Security Policy** | [docs.ultralytics.com/help/security](https://docs.ultralytics.com/help/security) |

--- a/docs/en/security/team.md
+++ b/docs/en/security/team.md
@@ -81,7 +81,7 @@ Use the `#compliance` channel for:
 
 !!! info "Trust Center"
 
-    **[trust.ultralytics.com](https://trust.ultralytics.com/)** is our centralized repository for all security policies, compliance certifications, and audit documentation.
+    **[trust.ultralytics.com](https://trust.ultralytics.com)** is our centralized repository for all security policies, compliance certifications, and audit documentation.
 
 ### Core Security Policies
 

--- a/docs/en/tools/software.md
+++ b/docs/en/tools/software.md
@@ -91,7 +91,7 @@ Once the **System Approver** approves your request, the **System Admin** will pr
 flowchart TD
 A@{ label: "Log into Vanta and navigate to <a href='https://app.vanta.com/c/ultralytics/access/systems/request'>My access requests</a> dashboard, or look up Vanta app in Slack, and Submit access request" } --> B{"Did you find the tool you need?"}:::decide
     B -- Yes --> C["Select the tool you need and request access"]:::proc
-    B -- No --> D["Follow <a href='https://handbook.ultralytics.com/tools/software/#3-software-approval-vendor-lifecycle'>New Software Approval Process</a>"]:::proc
+    B -- No --> D["Follow <a href='https://handbook.ultralytics.com/tools/software#3-software-approval-vendor-lifecycle'>New Software Approval Process</a>"]:::proc
     n3["Need access to a tool?"]:::start --> A
     C --> n4["Did the Approver approve your request?"]:::decide
     n4 -- Yes --> n1["Admin will provision you access or inform you how to gain access if the tool relies on shared credentials."]:::out

--- a/docs/en/workflows/ci-testing.md
+++ b/docs/en/workflows/ci-testing.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, CI/CD, continuous integration, testing, GitHub Actions, p
 
 # CI/Testing Workflow 🧪
 
-Continuous Integration (CI) is essential for maintaining high-quality code by catching issues early. This guide covers CI testing and quality checks for [Ultralytics](https://www.ultralytics.com/) projects.
+Continuous Integration (CI) is essential for maintaining high-quality code by catching issues early. This guide covers CI testing and quality checks for [Ultralytics](https://www.ultralytics.com) projects.
 
 ## CI Actions 🔄
 

--- a/docs/en/workflows/development.md
+++ b/docs/en/workflows/development.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, development workflow, pull requests, code review, Git, Gi
 
 # Development Workflow 💻
 
-This guide covers how Ultralytics employees and contributors plan, implement, review, test, and merge changes across [Ultralytics](https://www.ultralytics.com/) projects, including YOLO and related repositories.
+This guide covers how Ultralytics employees and contributors plan, implement, review, test, and merge changes across [Ultralytics](https://www.ultralytics.com) projects, including YOLO and related repositories.
 
 The workflow is intentionally lightweight: keep changes focused, make review easy, run the right checks, and leave enough context for teammates to understand the decision later.
 
@@ -435,7 +435,7 @@ For model behavior changes, include the dataset, model, command, hardware, and b
 Report bugs via [GitHub Issues](https://github.com/ultralytics/ultralytics/issues):
 
 1. **Check existing issues** first
-2. **Provide [Minimum Reproducible Example](https://docs.ultralytics.com/help/minimum-reproducible-example/)**
+2. **Provide [Minimum Reproducible Example](https://docs.ultralytics.com/help/minimum-reproducible-example)**
 3. **Describe environment**: OS, Python version, library versions, hardware (use `yolo checks` for diagnostics)
 4. **Explain expected vs actual behavior** with error messages
 
@@ -452,6 +452,6 @@ Many Ultralytics repositories use the [AGPL-3.0 license](https://www.ultralytics
 - [Documentation](documentation.md) - Writing and maintaining docs
 - [Code of Conduct](https://docs.ultralytics.com/help/code-of-conduct) - Community standards
 - [CLA Instructions](https://docs.ultralytics.com/help/CLA) - Contributor License Agreement guidance
-- [Minimum Reproducible Example](https://docs.ultralytics.com/help/minimum-reproducible-example/) - Bug report examples
+- [Minimum Reproducible Example](https://docs.ultralytics.com/help/minimum-reproducible-example) - Bug report examples
 - [Ultralytics Blog](https://www.ultralytics.com/blog) - Latest updates and tutorials
 - [Community Events](https://www.ultralytics.com/events) - Webinars and conferences

--- a/docs/en/workflows/documentation.md
+++ b/docs/en/workflows/documentation.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, documentation, Zensical, writing guides, YOLO docs, API d
 
 # Documentation Workflow 📚
 
-This guide covers writing, building, and maintaining documentation for [Ultralytics](https://www.ultralytics.com/) projects.
+This guide covers writing, building, and maintaining documentation for [Ultralytics](https://www.ultralytics.com) projects.
 
 ## Documentation Structure 🗂️
 

--- a/docs/en/workflows/product-development.md
+++ b/docs/en/workflows/product-development.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, product development, feature planning, release process, Y
 
 # Product Development Workflow 🚀
 
-This guide covers product planning, development cycles, and release processes for [Ultralytics](https://www.ultralytics.com/) products.
+This guide covers product planning, development cycles, and release processes for [Ultralytics](https://www.ultralytics.com) products.
 
 ## Product Philosophy 🎯
 
@@ -267,7 +267,7 @@ Define before building:
 - [YOLO26 model family](https://docs.ultralytics.com/models/yolo26)
 - [Export format support](https://docs.ultralytics.com/modes/export)
 - [Performance optimization](https://docs.ultralytics.com/guides/model-training-tips)
-- [Documentation quality](https://docs.ultralytics.com/)
+- [Documentation quality](https://docs.ultralytics.com)
 
 ### Upcoming Areas
 


### PR DESCRIPTION
Normalizes every Ultralytics URL in the repository to omit the terminating path slash.

## Scope

- **47 URL occurrences** across **22 files** (19 Markdown, 4 GitHub issue-template YAML).
- Covers the apex `ultralytics.com` and all subdomains present here: `www`, `docs`, `handbook`, `community`, `trust`.
- No other domains touched — `zensical.org`, `app.vanta.com`, `github.com`, `reddit.com`, `discord.com`, and `img.shields.io` are unchanged.

## Judgment calls

- **Fragment slash**: `docs/en/tools/software.md` had `.../tools/software/#3-software-approval-vendor-lifecycle` inside a Mermaid node's `<a href>`; the slash before the fragment was removed, leaving the anchor intact.
- **Encoded URL preserved**: the Discourse badge in `README.md` embeds `https%3A%2F%2Fcommunity.ultralytics.com` as a query parameter. It has no trailing slash and was deliberately left byte-identical; only the badge's own markdown link target was normalized.
- **Link text normalized too**: `docs/en/security/isms.md` displayed `docs.ultralytics.com/help/security/` as link text while its `href` already had no trailing slash. The text now matches the target.
- **`mailto:` untouched**: `security@ultralytics.com` and `glenn.jocher@ultralytics.com` are addresses, not URLs, and were excluded.
- **`mkdocs.yml` needed no change**: `site_url: https://handbook.ultralytics.com` was already slash-free. There are no base-URL constants or string concatenation anywhere — this is a docs-only repository with no application code, so no redirect maps, canonical logic, or sitemap code were affected.

## Validation

- `zensical build --strict` (the CI gate in `ci.yml`) — **passes, "No issues found"**.
- `prettier@3.8.5 --tab-width 4 --print-width 120 --check "docs/**/*.md"` — clean.
- `prettier@3.8.5 --print-width 120 --check "*.md" ".github/**/*.yml"` — clean.
- Post-change grep sweep for any `*.ultralytics.com` URL ending in `/` returns **zero matches**.

Note: `links.yml` runs lychee against the live network, so the shortened URLs are resolved by the production redirect behavior of each host rather than by anything in this repo.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Normalized 47 Ultralytics URLs across repository documentation and GitHub issue templates by removing trailing slashes for consistent URL formatting.

### 📊 Key Changes

- Updated links for `ultralytics.com`, `www.ultralytics.com`, `docs.ultralytics.com`, `handbook.ultralytics.com`, `community.ultralytics.com`, and `trust.ultralytics.com` to omit terminating slashes.
- Updated the Mermaid software-approval link to preserve its fragment while removing the slash before it.
- Aligned the displayed security-policy URL in `docs/en/security/isms.md` with its already-normalized target.
- Left non-Ultralytics domains, encoded badge parameters, email addresses, and the already-normalized `mkdocs.yml` site URL unchanged.
- Validation reported passing strict Zensical and Prettier checks, with no remaining trailing-slash Ultralytics URLs found by the post-change sweep.

### 🎯 Purpose & Impact

- Documentation links, README links, and issue-template examples now use a consistent slash-free format; no application code, redirect logic, canonical URL handling, or sitemap behavior changed.