### PR TITLE
Add Tianshu Li to development team

### DIFF
--- a/docs/en/contributions/how-to-contribute.md
+++ b/docs/en/contributions/how-to-contribute.md
@@ -245,6 +245,7 @@ Feel free to reach out to team members for guidance:
 | Sergiu Waxmann          | [sergiuwaxmann](https://github.com/sergiuwaxmann)                     |
 | Shuai (Louis) Lyu       | [ShuaiLYU](https://github.com/ShuaiLYU)                               |
 | Thomas Chuang           | [chuang091](https://github.com/chuang091)                             |
+| Tianshu Li              | [tianshu-Li715](https://github.com/tianshu-Li715)                     |
 | Yogendra Singh          | [yogendrasinghx](https://github.com/yogendrasinghx)                   |
 | Zinnia Pourdad          | [zinnialp](https://github.com/zinnialp)                               |
 | Zuzana Kontrikova       | [zkontri](https://github.com/zkontri)                                 |


### PR DESCRIPTION
## Summary

- add Tianshu Li to the development team directory
- link the `tianshu-Li715` GitHub profile

## Validation

- `.venv/bin/zensical build --strict`
- verified the GitHub profile via the GitHub API

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Added Tianshu Li and the `tianshu-Li715` GitHub profile to the development team directory.

### 📊 Key Changes

- Updated `docs/en/contributions/how-to-contribute.md`.
- Added Tianshu Li to the team member table.
- Linked the entry to [Tianshu Li’s GitHub profile](https://github.com/tianshu-Li715).

### 🎯 Purpose & Impact

- Makes Tianshu Li discoverable as a development team member for contributors seeking guidance.
- No other documentation or application behavior changed.